### PR TITLE
Add build scripts -- fail the build if swagger-ui has not been initialized

### DIFF
--- a/Swashbuckle/Swashbuckle.csproj
+++ b/Swashbuckle/Swashbuckle.csproj
@@ -126,10 +126,11 @@
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <!--  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />-->
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
+      <Error 
+	    Condition="!Exists('$(ProjectDir)..\swagger-ui\src\main\html\index.html')"
+	    Text="Could not find swagger-ui.  Have you done 'git submodule init' and 'git submodule update'?" />
   </Target>
   <Target Name="AfterBuild">
-  </Target> -->
+  </Target>
 </Project>

--- a/build
+++ b/build
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+$SYSTEMROOT/System32/cmd.exe /c "build.bat $*"
+exit $?

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,1 @@
+%SYSTEMROOT%\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe %~dp0\build.proj /p:Configuration=Release

--- a/build.proj
+++ b/build.proj
@@ -1,0 +1,10 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build" ToolsVersion="4.0">
+    <PropertyGroup>
+        <Configuration Condition="$(Configuration)==''">Debug</Configuration>
+    </PropertyGroup>
+
+    <Target Name="Build">
+        <MSBuild Projects="Swashbuckle.sln" />
+    </Target>
+
+	</Project>


### PR DESCRIPTION
Added .sh and .bat flavors of a root-level build project.  When building Swashbuckle with either the scripts or Visual Studio, if git submodules have not been initialized, fail the build.

Might be a more definitive way to know if this has been done, but the symptom typically is that when you go to use swagger, an exception that an embedded resource named "index.html" cannot be found.
