### PR TITLE
Allow ApiVersion to be specified by SwaggerSpecConfig

### DIFF
--- a/Swashbuckle/Models/SwaggerGenerator.cs
+++ b/Swashbuckle/Models/SwaggerGenerator.cs
@@ -48,7 +48,7 @@ namespace Swashbuckle.Models
 
             return new ResourceListing
             {
-                ApiVersion = "1.0",
+                ApiVersion = _config.ApiVersion,
                 SwaggerVersion = SwaggerVersion,
                 Apis = declarationLinks
             };
@@ -73,7 +73,7 @@ namespace Swashbuckle.Models
 
             return new ApiDeclaration
             {
-                ApiVersion = "1.0",
+                ApiVersion = _config.ApiVersion,
                 SwaggerVersion = SwaggerVersion,
                 BasePath = _config.BasePathResolver().TrimEnd('/'),
                 ResourcePath = apiDescriptionGroup.Key,

--- a/Swashbuckle/Models/SwaggerSpecConfig.cs
+++ b/Swashbuckle/Models/SwaggerSpecConfig.cs
@@ -18,6 +18,7 @@ namespace Swashbuckle.Models
         public SwaggerSpecConfig()
         {
             IgnoreObsoleteActions = false;
+            ApiVersion = "1.0";
             BasePathResolver = DefaultBasePathResolver;
             DeclarationKeySelector = DefaultDeclarationKeySelector;
             CustomTypeMappings = new Dictionary<Type, ModelSpec>();
@@ -27,6 +28,7 @@ namespace Swashbuckle.Models
         }
 
         public bool IgnoreObsoleteActions { get; set; }
+        public string ApiVersion { get; set; }
         internal Func<string> BasePathResolver { get; private set; }
         internal Func<ApiDescription, string> DeclarationKeySelector { get; private set; }
         internal IDictionary<Type, ModelSpec> CustomTypeMappings { get; private set; }


### PR DESCRIPTION
This is a possible solution for [Issue 26](https://github.com/domaindrivendev/Swashbuckle/issues/26).
