### PR TITLE
Added produces, consumes, authorizations.

### DIFF
--- a/Swashbuckle.Core/Swagger/SwaggerSpec.cs
+++ b/Swashbuckle.Core/Swagger/SwaggerSpec.cs
@@ -50,6 +50,15 @@ namespace Swashbuckle.Core.Swagger
 
         [JsonProperty("models")]
         public IDictionary<string, DataType> Models { get; set; }
+
+        [JsonProperty("produces")]
+        public IList<string> Produces { get; set; }
+
+        [JsonProperty("consumes")]
+        public IList<string> Consumes { get; set; }
+
+        [JsonProperty("authorizations")]
+        public IList<string> Authorizations { get; set; }
     }
 
     public class Api
@@ -95,6 +104,15 @@ namespace Swashbuckle.Core.Swagger
 
         [JsonProperty("responseMessages")]
         public IList<ResponseMessage> ResponseMessages { get; set; }
+
+        [JsonProperty("produces")]
+        public IList<string> Produces { get; set; }
+
+        [JsonProperty("consumes")]
+        public IList<string> Consumes { get; set; }
+
+        [JsonProperty("authorizations")]
+        public IList<string> Authorizations { get; set; }
     }
 
     public class Parameter


### PR DESCRIPTION
Per Swagger spec 1.2, the API and each individual operation can generate information about which MIME types it produces, which it consumes, and what authorization options are available. Adding these properties allows custom extensions to provide this information.
