### PR TITLE
Added produces, consumes to API and operation

### DIFF
--- a/Swashbuckle.Core/Swagger/ISwaggerProvider.cs
+++ b/Swashbuckle.Core/Swagger/ISwaggerProvider.cs
@@ -50,6 +50,12 @@ namespace Swashbuckle.Swagger
 
         [JsonProperty("models")]
         public IDictionary<string, DataType> Models { get; set; }
+
+        [JsonProperty("produces")]
+        public IList<string> Produces { get; set; }
+
+        [JsonProperty("consumes")]
+        public IList<string> Consumes { get; set; }
     }
 
     public class Api
@@ -95,6 +101,12 @@ namespace Swashbuckle.Swagger
 
         [JsonProperty("responseMessages")]
         public IList<ResponseMessage> ResponseMessages { get; set; }
+
+        [JsonProperty("produces")]
+        public IList<string> Produces { get; set; }
+
+        [JsonProperty("consumes")]
+        public IList<string> Consumes { get; set; }
     }
 
     public class Parameter


### PR DESCRIPTION
"produces" and "consumes" are string arrays for the API and Operation level that list MIME types that can be produced or consumed. This allows extensions to provide this information for the Swagger UI.
