### PR TITLE
Include API's content types from its description.

### DIFF
--- a/Swashbuckle.Core/Swagger/OperationGenerator.cs
+++ b/Swashbuckle.Core/Swagger/OperationGenerator.cs
@@ -29,7 +29,8 @@ namespace Swashbuckle.Swagger
                 Nickname = apiDescription.Nickname(),
                 Summary = apiDescription.Documentation,
                 Parameters = parameters,
-                ResponseMessages = new List<ResponseMessage>()
+                ResponseMessages = new List<ResponseMessage>(),
+                Produces = apiDescription.SupportedResponseFormatters.SelectMany(d => d.SupportedMediaTypes.Select(t => t.MediaType)).ToList()
             };
 
             var responseType = apiDescription.ActualResponseType();

--- a/Swashbuckle.Tests/App.config
+++ b/Swashbuckle.Tests/App.config
@@ -6,6 +6,10 @@
         <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.1.0.0" newVersion="5.1.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.1.0.0" newVersion="5.1.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>


### PR DESCRIPTION
Passes content types from response formatters to Swagger, allowing them to be chosen in the "Response Content Type" box.
