### PR TITLE
Fix for swagger codegen

### DIFF
--- a/Swashbuckle.Core/Swagger/ApplyActionXmlComments.cs
+++ b/Swashbuckle.Core/Swagger/ApplyActionXmlComments.cs
@@ -27,7 +27,9 @@ namespace Swashbuckle.Swagger
         {
             var methodNode = _navigator.SelectSingleNode(GetXPathFor(apiDescription.ActionDescriptor));
 
-            operation.Summary = GetChildValueOrDefault(methodNode, SummaryExpression);
+            string summary = GetChildValueOrDefault(methodNode, SummaryExpression);
+            if(!string.IsNullOrEmpty(summary))
+                operation.Summary = summary;
             operation.Notes = GetChildValueOrDefault(methodNode, RemarksExpression);
 
             foreach (var paramDesc in apiDescription.ParameterDescriptions)

--- a/Swashbuckle.Core/Swagger/OperationGenerator.cs
+++ b/Swashbuckle.Core/Swagger/OperationGenerator.cs
@@ -27,7 +27,7 @@ namespace Swashbuckle.Swagger
             {
                 Method = apiDescription.HttpMethod.Method,
                 Nickname = apiDescription.Nickname(),
-                Summary = apiDescription.Documentation,
+                Summary = apiDescription.Documentation ?? "",
                 Parameters = parameters,
                 ResponseMessages = new List<ResponseMessage>()
             };


### PR DESCRIPTION
Now the "summary" field are always present even if no documentation are found. So the swagger code-gen won't crash anymore generating clients for API without docs.
