### PR TITLE
Include API's response content types and parameter content types 

### DIFF
--- a/Swashbuckle.Core/Swagger/OperationGenerator.cs
+++ b/Swashbuckle.Core/Swagger/OperationGenerator.cs
@@ -29,7 +29,9 @@ namespace Swashbuckle.Swagger
                 Nickname = apiDescription.Nickname(),
                 Summary = apiDescription.Documentation,
                 Parameters = parameters,
-                ResponseMessages = new List<ResponseMessage>()
+                ResponseMessages = new List<ResponseMessage>(),
+                Produces = apiDescription.SupportedResponseFormatters.SelectMany(d => d.SupportedMediaTypes.Select(t => t.MediaType)).ToList(),
+                Consumes = apiDescription.SupportedRequestBodyFormatters.SelectMany(d => d.SupportedMediaTypes.Select(t => t.MediaType)).ToList()
             };
 
             var responseType = apiDescription.ActualResponseType();


### PR DESCRIPTION
Passes content types from response formatters to Swagger, allowing them to be chosen in the "Response Content Type" box and the "Parameter content type" box.
