### PR TITLE
Added support for API metadata (Info object) and OAuth2 authorization

### DIFF
--- a/Swashbuckle.Core/Application/SwaggerSpecConfig.cs
+++ b/Swashbuckle.Core/Application/SwaggerSpecConfig.cs
@@ -19,6 +19,8 @@ namespace Swashbuckle.Application
 
         internal Func<HttpRequestMessage, string> BasePathResolver { get; set; }
         internal Func<HttpRequestMessage, string> TargetVersionResolver { get; set; }
+        internal Info Info { get; set; }
+        internal Dictionary<string, Authorization> Authorizations { get; set; }
 
         private bool _ignoreObsoleteActions;
         private Func<ApiDescription, string, bool> _versionSupportResolver;
@@ -61,6 +63,21 @@ namespace Swashbuckle.Application
         public SwaggerSpecConfig IgnoreObsoleteActions()
         {
             _ignoreObsoleteActions = true;
+            return this;
+        }
+
+        public SwaggerSpecConfig ApiInfo(Info info)
+        {
+            this.Info = info;
+            return this;
+        }
+
+        public SwaggerSpecConfig SetOAuth2Authorization(Authorization auth)
+        {
+            if (this.Authorizations == null)
+                this.Authorizations = new Dictionary<string,Authorization>();
+
+            this.Authorizations["oauth2"] = auth;
             return this;
         }
 
@@ -138,7 +155,9 @@ namespace Swashbuckle.Application
                 _customTypeMappings,
                 _polymorphicTypes,
                 modelFilters,
-                operationFilters);
+                operationFilters,
+                this.Info,
+                this.Authorizations);
         }
     }
 }

--- a/Swashbuckle.Core/Swagger/ApiExplorerAdapter.cs
+++ b/Swashbuckle.Core/Swagger/ApiExplorerAdapter.cs
@@ -17,6 +17,8 @@ namespace Swashbuckle.Swagger
         private readonly IEnumerable<PolymorphicType> _polymorphicTypes;
         private readonly IEnumerable<IModelFilter> _modelFilters;
         private readonly IEnumerable<IOperationFilter> _operationFilters;
+        private readonly Info _info;
+        private readonly Dictionary<string, Authorization> _authorizations;
 
         public ApiExplorerAdapter(
             IApiExplorer apiExplorer,
@@ -26,7 +28,9 @@ namespace Swashbuckle.Swagger
             Dictionary<Type, Func<DataType>> customTypeMappings,
             IEnumerable<PolymorphicType> polymorphicTypes,
             IEnumerable<IModelFilter> modelFilters,
-            IEnumerable<IOperationFilter> operationFilters)
+            IEnumerable<IOperationFilter> operationFilters,
+            Info info,
+            Dictionary<string, Authorization> authorizations)
         {
             _apiExplorer = apiExplorer;
             _ignoreObsoleteActions = ignoreObsoleteActions;
@@ -36,6 +40,8 @@ namespace Swashbuckle.Swagger
             _polymorphicTypes = polymorphicTypes;
             _modelFilters = modelFilters;
             _operationFilters = operationFilters;
+            _info = info;
+            _authorizations = authorizations;
         }
 
         public ResourceListing GetListing(string basePath, string version)
@@ -50,7 +56,9 @@ namespace Swashbuckle.Swagger
             {
                 SwaggerVersion = SwaggerVersion,
                 ApiVersion = version,
-                Apis = resources
+                Apis = resources,
+                Info = _info,
+                Authorizations = _authorizations
             };
         }
 

--- a/Swashbuckle.Core/Swagger/ApplyActionXmlComments.cs
+++ b/Swashbuckle.Core/Swagger/ApplyActionXmlComments.cs
@@ -15,6 +15,7 @@ namespace Swashbuckle.Swagger
         private const string RemarksExpression = "remarks";
         private const string ParameterExpression = "param[@name=\"{0}\"]";
         private const string ResponseExpression = "response";
+        private const string ScopeExpression = "scope";
 
         private readonly XPathNavigator _navigator;
 
@@ -44,6 +45,14 @@ namespace Swashbuckle.Swagger
             {
                 operation.ResponseMessages.Add(responseMessage);
             }
+
+            var scopes = GetAuthorizationScopes(methodNode);
+            if (scopes.Any())
+            {
+                operation.Authorizations = new Dictionary<string,IList<Scope>>();
+                operation.Authorizations["oauth2"] = scopes.ToList();
+            }
+
         }
 
         private static string GetXPathFor(HttpActionDescriptor actionDescriptor)
@@ -99,6 +108,19 @@ namespace Swashbuckle.Swagger
                         Code = Int32.Parse(iterator.Current.GetAttribute("code", String.Empty)),
                         Message = iterator.Current.Value
                     };
+            }
+        }
+
+        private static IEnumerable<Scope> GetAuthorizationScopes(XPathNavigator node)
+        {
+            var iterator = node.Select(ScopeExpression);
+            while (iterator.MoveNext())
+            {
+                yield return new Scope
+                {
+                    ScopeId = iterator.Current.GetAttribute("code", String.Empty),
+                    Description = iterator.Current.Value
+                };
             }
         }
     }

--- a/Swashbuckle.Core/Swagger/ISwaggerProvider.cs
+++ b/Swashbuckle.Core/Swagger/ISwaggerProvider.cs
@@ -20,6 +20,12 @@ namespace Swashbuckle.Swagger
 
         [JsonProperty("apis")]
         public IList<Resource> Apis { get; set; }
+
+        [JsonProperty("info")]
+        public Info Info { get; set; }
+
+        [JsonProperty("authorizations")]
+        public IDictionary<string, Authorization> Authorizations { get; set; }
     }
 
     public class Resource
@@ -29,6 +35,7 @@ namespace Swashbuckle.Swagger
 
         [JsonProperty("description")]
         public string Description { get; set; }
+
     }
 
     public class ApiDeclaration
@@ -56,6 +63,9 @@ namespace Swashbuckle.Swagger
 
         [JsonProperty("consumes")]
         public IList<string> Consumes { get; set; }
+
+        [JsonProperty("authorizations")]
+        public Dictionary<string, IList<Scope>> Authorizations { get; set; }
     }
 
     public class Api
@@ -101,6 +111,9 @@ namespace Swashbuckle.Swagger
 
         [JsonProperty("responseMessages")]
         public IList<ResponseMessage> ResponseMessages { get; set; }
+
+        [JsonProperty("authorizations")]
+        public Dictionary<string, IList<Scope>> Authorizations { get; set; }
 
         [JsonProperty("produces")]
         public IList<string> Produces { get; set; }
@@ -180,4 +193,108 @@ namespace Swashbuckle.Swagger
         [JsonProperty("discriminator")]
         public string Discriminator { get; set; }
     }
+
+    public class Info
+    {
+        [JsonProperty("title")]
+        public string Title { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("termsOfServiceUrl")]
+        public string TermsOfServiceUrl { get; set; }
+
+        [JsonProperty("contact")]
+        public string Contact { get; set; }
+
+        [JsonProperty("license")]
+        public string License { get; set; }
+
+        [JsonProperty("licenseUrl")]
+        public string LicenseUrl { get; set; }
+    }
+
+    public class Authorization
+    {
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("passAs")]
+        public string PassAs { get; set; }
+
+        [JsonProperty("keyname")]
+        public string KeyName { get; set; }
+
+        [JsonProperty("scopes")]
+        public IList<Scope> Scopes { get; set; }
+
+        [JsonProperty("grantTypes")]
+        public GrantTypes GrantTypes { get; set; }
+    }
+
+    public class Scope
+    {
+        [JsonProperty("scope")]
+        public string ScopeId { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+    }
+
+    public class GrantTypes
+    {
+        [JsonProperty("implicit")]
+        public ImplicitGrant ImplicitGrant { get; set; }
+
+        [JsonProperty("authorization_code")]
+        public AuthorizationCodeGrant AuthorizationCode { get; set; }
+    }
+
+    public class ImplicitGrant
+    {
+        [JsonProperty("loginEndpoint")]
+        public LoginEndpoint LoginEndpoint { get; set; }
+
+        [JsonProperty("tokenName")]
+        public string TokenName { get; set; }
+    }
+
+    public class AuthorizationCodeGrant
+    {
+        [JsonProperty("tokenRequestEndpoint")]
+        public TokenRequestEndpoint TokenRequestEndpoint { get; set; }
+
+        [JsonProperty("tokenEndpoint")]
+        public TokenEndpoint TokenEndpoint { get; set; }
+    }
+
+    public class LoginEndpoint
+    {
+        [JsonProperty("url")]
+        public string Url { get; set; }
+    }
+
+    public class TokenRequestEndpoint
+    {
+        [JsonProperty("url")]
+        public string Url { get; set; }
+
+        [JsonProperty("clientIdName")]
+        public string ClientIdName { get; set; }
+
+        [JsonProperty("clientSecretName")]
+        public string ClientSecretName { get; set; }
+    }
+
+    public class TokenEndpoint
+    {
+        [JsonProperty("url")]
+        public string Url { get; set; }
+
+        [JsonProperty("tokenName")]
+        public string TokenName { get; set; }
+    }
+
+
 }


### PR DESCRIPTION
We use OAuth2 authorization in our API with [Thinktecture Authorization Server](https://github.com/thinktecture/Thinktecture.AuthorizationServer) so I wanted my Swagger docs to describe it.
I added the missing objects related to authorization (mainly focused on OAuth2) of the spec and added new extensibility options to feed the info to Swashbuckle.
While at it I also added the Info object (API metadata) in the same manner.

Here's an example:

```
        Swashbuckle.Application.SwaggerSpecConfig.Customize(c =>
            {
                c.ApiInfo(new Swashbuckle.Swagger.Info
                    {
                        Title = "Pets API",
                        Description = "This API manages your pets",
                        Contact = "you@example.org"
                    });
                c.SetOAuth2Authorization(new Swashbuckle.Swagger.Authorization
                {
                    Type = "oauth2",
                    Scopes = new List<Swashbuckle.Swagger.Scope> {
                        new Swashbuckle.Swagger.Scope { ScopeId = "pets.read", Description = "Read your pets" },
                        new Swashbuckle.Swagger.Scope { ScopeId = "pets.write", Description = "Modify your pets" }
                    },
                    GrantTypes = new Swashbuckle.Swagger.GrantTypes {
                        ImplicitGrant = new Swashbuckle.Swagger.ImplicitGrant {
                            LoginEndpoint = new Swashbuckle.Swagger.LoginEndpoint {
                                Url = "https://yourapi/oauth/authorize"
                            },
                            TokenName = "access_token"
                        }
                    }
                });
            }
```

Lastly, I added new unofficial XML comments tags to describe scopes:

```
    /// <scope code="pets.read">Read your pets</scope>
    /// <scope code="pets.write">Modify your pets</scope>
```

Note that the Swagger UI OAuth2 initialization function is currently commented out; you'll find it in index.html, if you reenable it and change your client_id etc, I can confirm it works. The o2c.html redirect target must be copied to the root of your domain though.
