### PR TITLE
Allow customizing sort order for API groups

### DIFF
--- a/Swashbuckle.Core/Application/SwaggerSpecConfig.cs
+++ b/Swashbuckle.Core/Application/SwaggerSpecConfig.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq.Expressions;
 using System.Net.Http;
 using System.Web.Http.Description;
 using System.Linq;
@@ -23,6 +22,7 @@ namespace Swashbuckle.Application
         private bool _ignoreObsoleteActions;
         private Func<ApiDescription, string, bool> _versionSupportResolver;
         private Func<ApiDescription, string> _resourceNameResolver;
+        private IComparer<string> _groupComparer;
         private readonly Dictionary<Type, Func<DataType>> _customTypeMappings;
         private readonly List<PolymorphicType> _polymorphicTypes;
 
@@ -37,6 +37,7 @@ namespace Swashbuckle.Application
             _ignoreObsoleteActions = false;
             _versionSupportResolver = (apiDesc, version) => true;
             _resourceNameResolver = (apiDesc) => apiDesc.ActionDescriptor.ControllerDescriptor.ControllerName;
+            _groupComparer = Comparer<string>.Default;
             _customTypeMappings = new Dictionary<Type, Func<DataType>>();
             _polymorphicTypes = new List<PolymorphicType>();
 
@@ -75,6 +76,13 @@ namespace Swashbuckle.Application
         {
             if (resourceNameResolver == null) throw new ArgumentNullException("resourceNameResolver");
             _resourceNameResolver = resourceNameResolver;
+            return this;
+        }
+
+        public SwaggerSpecConfig SortDeclarationsBy(IComparer<string> groupComparer)
+        {
+            if (groupComparer == null) throw new ArgumentNullException("groupComparer");
+            _groupComparer = groupComparer;
             return this;
         }
 
@@ -135,6 +143,7 @@ namespace Swashbuckle.Application
                 _ignoreObsoleteActions,
                 _versionSupportResolver,
                 _resourceNameResolver,
+                _groupComparer,
                 _customTypeMappings,
                 _polymorphicTypes,
                 modelFilters,

--- a/Swashbuckle.Core/Swagger/ApiExplorerAdapter.cs
+++ b/Swashbuckle.Core/Swagger/ApiExplorerAdapter.cs
@@ -13,6 +13,7 @@ namespace Swashbuckle.Swagger
         private readonly bool _ignoreObsoleteActions;
         private readonly Func<ApiDescription, string, bool> _versionSupportResolver;
         private readonly Func<ApiDescription, string> _resourceNameResolver;
+        private readonly IComparer<string> _groupComparer;
         private readonly Dictionary<Type, Func<DataType>> _customTypeMappings;
         private readonly IEnumerable<PolymorphicType> _polymorphicTypes;
         private readonly IEnumerable<IModelFilter> _modelFilters;
@@ -23,6 +24,7 @@ namespace Swashbuckle.Swagger
             bool ignoreObsoleteActions,
             Func<ApiDescription, string, bool> resoveVersionSupport,
             Func<ApiDescription, string> resolveResourceName,
+            IComparer<string> groupComparer,
             Dictionary<Type, Func<DataType>> customTypeMappings,
             IEnumerable<PolymorphicType> polymorphicTypes,
             IEnumerable<IModelFilter> modelFilters,
@@ -32,6 +34,7 @@ namespace Swashbuckle.Swagger
             _ignoreObsoleteActions = ignoreObsoleteActions;
             _versionSupportResolver = resoveVersionSupport;
             _resourceNameResolver = resolveResourceName;
+            _groupComparer = groupComparer;
             _customTypeMappings = customTypeMappings;
             _polymorphicTypes = polymorphicTypes;
             _modelFilters = modelFilters;
@@ -86,7 +89,7 @@ namespace Swashbuckle.Swagger
                 .Where(apiDesc => !_ignoreObsoleteActions || !apiDesc.IsMarkedObsolete())
                 .Where(apiDesc => _versionSupportResolver(apiDesc, version))
                 .GroupBy(apiDesc => _resourceNameResolver(apiDesc))
-                .OrderBy(group => group.Key)
+                .OrderBy(group => group.Key, _groupComparer)
                 .ToArray();
         }
 

--- a/Swashbuckle.Tests/SwaggerSpec/CoreTests.cs
+++ b/Swashbuckle.Tests/SwaggerSpec/CoreTests.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using Swashbuckle.Application;
 using Swashbuckle.Dummy.Controllers;
@@ -342,6 +343,30 @@ namespace Swashbuckle.Tests.SwaggerSpec
         }
 
         [Test]
+        public void It_should_support_customized_api_group_ordering()
+        {
+            _swaggerSpecConfig.SortDeclarationsBy(new DescendingAlphabeticComparer());
+
+            var listing = Get<JObject>("http://tempuri.org/swagger/api-docs/");
+
+            var expected = JObject.FromObject(
+                new
+                {
+                    swaggerVersion = "1.2",
+                    apiVersion = "1.0",
+                    apis = new object[]
+                    {
+                        new { path = "/Products" },
+                        new { path = "/Customers" }
+                    }
+                });
+            Assert.AreEqual(expected.ToString(), listing.ToString());
+
+            Assert.NotNull(Get<JObject>("http://tempuri.org/swagger/api-docs/Products"));
+            Assert.NotNull(Get<JObject>("http://tempuri.org/swagger/api-docs/Customers"));
+        }
+
+        [Test]
         public void It_should_support_configurable_filters_for_modifying_generated_operations()
         {
             _swaggerSpecConfig.OperationFilter<AddResponseCodes>();
@@ -360,6 +385,14 @@ namespace Swashbuckle.Tests.SwaggerSpec
             public void Apply(Operation operation, DataTypeRegistry dataTypeRegistry, System.Web.Http.Description.ApiDescription apiDescription)
             {
                 operation.ResponseMessages.Add(new ResponseMessage { Code = 200, Message = "It's all good!" });
+            }
+        }
+
+        class DescendingAlphabeticComparer : IComparer<string>
+        {
+            public int Compare(string x, string y)
+            {
+                return y.CompareTo(x);
             }
         }
     }


### PR DESCRIPTION
Consider an API that has a specific workflow.  I wish to communicate this workflow in the order of my API groups, e.g.
1.  Auth
2.  Search
3.  Purchase
4.  Download

Customize:

``` c#
            SwaggerSpecConfig.Customize(c =>
            {
                c.SortDeclarationsBy(new ApiGrouping());
            });
```

Example customization:

``` c#
        private class ApiGrouping : IComparer<string>
        {
            private readonly Dictionary<string, int> _orderPreferences = new Dictionary<string, int>();

            public ApiGrouping()
            {
                int index = 0;
                foreach (var str in new[] { "Auth", "Search", "Purchase", "Download" })
                {
                    _orderPreferences.Add(str, index++);
                }
            }

            public int Compare(string x, string y)
            {
                if (_orderPreferences.ContainsKey(x) && _orderPreferences.ContainsKey(y))
                {
                    return _orderPreferences[x].CompareTo(_orderPreferences[y]);
                }

                return Comparer<string>.Default.Compare(x, y);
            }
        }
```

Could consider adding a convenience:

``` c#
   c.PreferredApiGroupOrder("Auth", "Search", "Purchase", "Download" );
```
