### PR TITLE
Fix bug where collections of primitives would result in an exception

### DIFF
--- a/Swashbuckle.Core/Swagger/DataTypeRegistry.cs
+++ b/Swashbuckle.Core/Swagger/DataTypeRegistry.cs
@@ -103,7 +103,7 @@ namespace Swashbuckle.Swagger
             Type itemType;
             if (type.IsEnumerable(out itemType))
             {
-                if (itemType.IsEnumerable() && !IndeterminateMappings.ContainsKey(itemType))
+                if (itemType.IsEnumerable() && !IsSupportedEnumerableItem(itemType))
                     throw new InvalidOperationException(
                         String.Format("Type {0} is not supported. Swagger does not support containers of containers", type));
 
@@ -197,6 +197,11 @@ namespace Swashbuckle.Swagger
             }
 
             return new PolymorphicType(type, true);
+        }
+
+        private static bool IsSupportedEnumerableItem(Type itemType)
+        {
+            return IndeterminateMappings.ContainsKey(itemType) || PrimitiveMappings.ContainsKey(itemType);
         }
     }
 }

--- a/Swashbuckle.Dummy.Core/Controllers/CollectionOfPrimitivesController.cs
+++ b/Swashbuckle.Dummy.Core/Controllers/CollectionOfPrimitivesController.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Web.Http;
+
+namespace Swashbuckle.Dummy.Controllers
+{
+    public class CollectionOfPrimitivesController : ApiController
+    {
+        public int Create(IEnumerable<string> strings)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Swashbuckle.Dummy.Core/Swashbuckle.Dummy.Core.csproj
+++ b/Swashbuckle.Dummy.Core/Swashbuckle.Dummy.Core.csproj
@@ -58,6 +58,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Controllers\CollectionOfPrimitivesController.cs" />
     <Compile Include="Controllers\SelfReferencingTypesController.cs" />
     <Compile Include="Controllers\CustomersController.cs" />
     <Compile Include="Controllers\DynamicTypesController.cs" />

--- a/Swashbuckle.Tests/SwaggerSpec/ModelTests.cs
+++ b/Swashbuckle.Tests/SwaggerSpec/ModelTests.cs
@@ -243,8 +243,6 @@ namespace Swashbuckle.Tests.SwaggerSpec
             Assert.AreEqual(expected.ToString(), required.ToString());
         }
 
-
-
         [Test]
         [ExpectedException(typeof(InvalidOperationException))]
         public void It_should_honor_the_swagger_spec_and_not_support_containers_of_containers()
@@ -252,6 +250,14 @@ namespace Swashbuckle.Tests.SwaggerSpec
             SetUpDefaultRouteFor<UnsupportedTypesController>();
 
             Get<JObject>("http://tempuri.org/swagger/api-docs/Matrixes");
+        }
+
+        [Test]
+        public void It_should_support_collections_of_primitives()
+        {
+            SetUpDefaultRouteFor<CollectionOfPrimitivesController>();
+
+            Get<JObject>("http://tempuri.org/swagger/api-docs/CollectionOfPrimitives");
         }
 
         [Test]


### PR DESCRIPTION
Presumably this is a bug -- I think this is the right fix...
