### PR TITLE
IIS Hosting - Alternative to setting the runAllManagedModulesForAllRequests attribute

### DIFF
--- a/Swashbuckle.WebHost/Nuget/Content/Web.config.transform
+++ b/Swashbuckle.WebHost/Nuget/Content/Web.config.transform
@@ -1,5 +1,7 @@
 ﻿<configuration>
   <system.webServer>
-    <modules runAllManagedModulesForAllRequests="true" />
+    <handlers>
+      <add name="SwashbuckleUiHandler" verb="*" path="swagger/ui/*" type="Swashbuckle.Application.SwaggerUiHandler, Swashbuckle.Core" preCondition="managedHandler"/>
+    </handlers>
   </system.webServer>
 </configuration>


### PR DESCRIPTION
Registers the Swashbuckle.Application.SwaggerUiHandler in the handlers section of the Web.config to avoid having to set the runAllManagedModulesForAllRequests attribute to TRUE.
