### PR TITLE
Content negotiation

### DIFF
--- a/Swashbuckle.Core/Application/SwaggerSpecHandler.cs
+++ b/Swashbuckle.Core/Application/SwaggerSpecHandler.cs
@@ -37,18 +37,25 @@ namespace Swashbuckle.Application
                 ? ContentFor(request, swaggerProvider.GetListing(basePath, version))
                 : ContentFor(request, swaggerProvider.GetDeclaration(basePath, version, resourceName.ToString()));
 
+            var code = content != null ? HttpStatusCode.OK : HttpStatusCode.NotFound;
+
             var tcs = new TaskCompletionSource<HttpResponseMessage>();
-            tcs.SetResult(new HttpResponseMessage(HttpStatusCode.OK)
+            
+            tcs.SetResult(new HttpResponseMessage(code)
             {
                 Content = content
             });
             return tcs.Task;
         }
 
-        private HttpContent ContentFor<T>(HttpRequestMessage request, T value)
+        private HttpContent ContentFor<T>(HttpRequestMessage request, T value) where T : class
         {
             var negotiator = request.GetConfiguration().Services.GetContentNegotiator();
             var result = negotiator.Negotiate(typeof (T), request, request.GetConfiguration().Formatters);
+
+            if (value == null)
+                return null;
+
             return new ObjectContent(typeof(T), value, result.Formatter, result.MediaType);
         }
     }

--- a/Swashbuckle.Core/Application/SwaggerUiHandler.cs
+++ b/Swashbuckle.Core/Application/SwaggerUiHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
@@ -40,6 +41,9 @@ namespace Swashbuckle.Application
             var resourceStream = (customResourceDescriptor == null)
                 ? GetType().Assembly.GetManifestResourceStream(uiPath)
                 : GetCustomResourceStream(customResourceDescriptor);
+
+            if (resourceStream == null)
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
 
             HttpContent content = new StreamContent(resourceStream);
             if (uiPath == "index.html")

--- a/Swashbuckle.Core/Swagger/ApiExplorerAdapter.cs
+++ b/Swashbuckle.Core/Swagger/ApiExplorerAdapter.cs
@@ -60,7 +60,10 @@ namespace Swashbuckle.Swagger
         public ApiDeclaration GetDeclaration(string basePath, string version, string resourceName)
         {
             var apiDescriptionGroup = GetApplicableApiDescriptions(version)
-                .Single(apiDescGrp => apiDescGrp.Key == resourceName);
+                .SingleOrDefault(apiDescGrp => apiDescGrp.Key == resourceName);
+
+            if (apiDescriptionGroup == null)
+                return null;
 
             var dataTypeRegistry = new DataTypeRegistry(_customTypeMappings, _polymorphicTypes, _modelFilters);
             var operationGenerator = new OperationGenerator(dataTypeRegistry, _operationFilters);

--- a/Swashbuckle.Core/Swagger/DataTypeRegistry.cs
+++ b/Swashbuckle.Core/Swagger/DataTypeRegistry.cs
@@ -76,9 +76,9 @@ namespace Swashbuckle.Swagger
             {
                 return _complexMappings.ToDictionary(entry => entry.Value.Id, entry => entry.Value);
             }
-            catch (ArgumentException)
+            catch (ArgumentException ex)
             {
-                throw new InvalidOperationException("Failed to generate Swagger models with unique Id's. Do you have multiple API types with the same class name?");
+                throw new InvalidOperationException("Failed to generate Swagger models with unique Id's. Do you have multiple API types with the same class name?", ex);
             }
         }
 

--- a/Swashbuckle.Core/Swagger/ISwaggerProvider.cs
+++ b/Swashbuckle.Core/Swagger/ISwaggerProvider.cs
@@ -7,6 +7,7 @@ namespace Swashbuckle.Swagger
     {
         ResourceListing GetListing(string basePath, string version);
 
+        /// <returns>An <see cref="ApiDeclaration"/> or <c>null</c> if <see cref="resourceName"/> is not found.</returns>
         ApiDeclaration GetDeclaration(string basePath, string version, string resourceName);
     }
 

--- a/Swashbuckle.Tests/HttpMessageHandlerTestsBase.cs
+++ b/Swashbuckle.Tests/HttpMessageHandlerTestsBase.cs
@@ -78,7 +78,7 @@ namespace Swashbuckle.Tests
             return responseMessage.Content.ReadAsStringAsync().Result;
         }
 
-        private HttpResponseMessage ExecuteGet(string uri)
+        protected HttpResponseMessage ExecuteGet(string uri)
         {
             if (Handler == null)
                 throw new InvalidOperationException("Handler not set");

--- a/Swashbuckle.Tests/SwaggerSpec/CoreTests.cs
+++ b/Swashbuckle.Tests/SwaggerSpec/CoreTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Net;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using Swashbuckle.Application;
@@ -298,6 +299,14 @@ namespace Swashbuckle.Tests.SwaggerSpec
 
             var declaration = Get<JObject>("http://tempuri.org/swagger/api-docs/Products");
             Assert.AreEqual("http://custombasepath.com", (string)declaration["basePath"]);
+        }
+
+        [Test]
+        public void It_should_handle_missing_as_404()
+        {
+            var result = ExecuteGet("http://tempuri.org/swagger/api-docs/NoSuchController");
+            
+            Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
         }
         
         [Test]

--- a/Swashbuckle.Tests/SwaggerSpec/ModelTests.cs
+++ b/Swashbuckle.Tests/SwaggerSpec/ModelTests.cs
@@ -249,7 +249,7 @@ namespace Swashbuckle.Tests.SwaggerSpec
         {
             SetUpDefaultRouteFor<UnsupportedTypesController>();
 
-            Get<JObject>("http://tempuri.org/swagger/api-docs/Matrixes");
+            Get<JObject>("http://tempuri.org/swagger/api-docs/UnsupportedTypes");
         }
 
         [Test]

--- a/Swashbuckle.Tests/SwaggerUi/SwaggerUiTests.cs
+++ b/Swashbuckle.Tests/SwaggerUi/SwaggerUiTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System.Net;
+using System.Net.Http;
 using System.Threading;
 using System.Web.Http.Hosting;
 using System.Web.Http.Routing;
@@ -32,6 +33,14 @@ namespace Swashbuckle.Tests.SwaggerUi
             var content = GetAsString("http://tempuri.org/swagger/ui/index.html");
 
             Assert.IsTrue(content.Contains("swagger-ui-container"), "Expected index.html content not found");
+        }
+
+        [Test]
+        public void It_should_handle_not_found()
+        {
+            var content = ExecuteGet("http://tempuri.org/swagger/ui/no/such/resource.html");
+
+            Assert.That(content.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
         }
 
         [Test]


### PR DESCRIPTION
These two commits return 404 Not Found instead of 500 Internal Server Error and use content negotiation (using the JsonFormatter registered on HttpConfiguration) so that requests that ask for xml receive xml.
