### PR TITLE
Update swagger ui oAuth2 flow to include openID connect parameters

### DIFF
--- a/Swashbuckle.Core/Application/SwaggerUiConfig.cs
+++ b/Swashbuckle.Core/Application/SwaggerUiConfig.cs
@@ -37,6 +37,8 @@ namespace Swashbuckle.Application
         internal string OAuth2AppName { get; private set; }
         internal string OAuth2Realm { get; private set; }
         internal string OAuth2ClientId { get; private set; }
+        internal string OAuth2State { get; set; }
+        internal string OAuth2Nonce { get; set; }
 
         public static void Customize(Action<SwaggerUiConfig> customize)
         {
@@ -77,6 +79,21 @@ namespace Swashbuckle.Application
             OAuth2ClientId = clientId;
             OAuth2Realm = realm;
             OAuth2AppName = appName;
+        }
+
+        /// <summary>
+        /// Enable oauth with optional parameter for opendid connect
+        /// </summary>
+        /// <param name="clientId">OAuth 2.0 Client Identifier valid at the Authorization Server</param>
+        /// <param name="realm">Optional indicate the scope of protection in the manner described in HTTP/1.1 [RFC2617]</param>
+        /// <param name="appName"></param>
+        /// <param name="state">Optional opaque value used to maintain state between the request and the callback. </param>
+        /// <param name="nonce">String value used to associate a Client session with an ID Token, and to mitigate replay attacks</param>
+        public void EnableOAuth2Support(string clientId, string realm, string appName, string state, string nonce)
+        {
+            OAuth2State = state;
+            OAuth2Nonce = nonce;
+            EnableOAuth2Support(clientId, realm, appName);
         }
     }
 

--- a/Swashbuckle.Core/Application/SwaggerUiHandler.cs
+++ b/Swashbuckle.Core/Application/SwaggerUiHandler.cs
@@ -88,7 +88,9 @@ namespace Swashbuckle.Application
                 .Replace("%(OAuth2Enabled)", _swaggerUiConfig.OAuth2Enabled.ToString().ToLower())
                 .Replace("%(OAuth2ClientId)", "\"" + _swaggerUiConfig.OAuth2ClientId + "\"")
                 .Replace("%(OAuth2Realm)", "\"" + _swaggerUiConfig.OAuth2Realm + "\"")
-                .Replace("%(OAuth2AppName)", "\"" + _swaggerUiConfig.OAuth2AppName + "\"");
+                .Replace("%(OAuth2AppName)", "\"" + _swaggerUiConfig.OAuth2AppName + "\"")
+                .Replace("%(OAuth2State)", "\"" + _swaggerUiConfig.OAuth2State + "\"")
+                .Replace("%(OAuth2Nonce)", "\"" + _swaggerUiConfig.OAuth2Nonce + "\"");
 
             // Special case - only applicable to index.html
             var stylesheetIncludes = String.Join("\r\n", _swaggerUiConfig.InjectedStylesheetPaths

--- a/Swashbuckle.Core/SwaggerExtensions/index.html
+++ b/Swashbuckle.Core/SwaggerExtensions/index.html
@@ -36,7 +36,9 @@
                 oAuth2Enabled: %(OAuth2Enabled),
                 oAuth2ClientId: %(OAuth2ClientId),
                 oAuth2Realm: %(OAuth2Realm),
-                oAuth2AppName: %(OAuth2AppName)
+                oAuth2AppName: %(OAuth2AppName),
+                oAuth2State: %(OAuth2State),
+                oAuth2Nonce: %(OAuth2Nonce)
             }
 
             window.swaggerUi = new SwaggerUi({
@@ -51,7 +53,9 @@
                         initOAuth({
                           clientId: sbConfig.oAuth2ClientId,
                           realm: sbConfig.oAuth2Realm,
-                          appName: sbConfig.oAuth2AppName
+                          appName: sbConfig.oAuth2AppName,
+                          state: sbConfig.oAuth2State,
+                          nonce: sbConfig.oAuth2Nonce
                         });
                     }
                     $('pre code').each(function (i, e) {

--- a/Swashbuckle.Core/SwaggerExtensions/swagger-oauth.js
+++ b/Swashbuckle.Core/SwaggerExtensions/swagger-oauth.js
@@ -3,6 +3,8 @@ var popupMask;
 var popupDialog;
 var clientId;
 var realm;
+var nonce;
+var state;
 
 function handleLogin() {
   var scopes = [];
@@ -77,6 +79,13 @@ function handleLogin() {
     var redirectUrl = host.protocol + '//' + host.host + "/swagger/ui/o2c.html";
     var url = null;
 
+    var scopes = [];
+    var o = $('.api-popup-scopes').find('input:checked');
+
+    for (k = 0; k < o.length; k++) {
+        scopes = scopes.concat($(o[k]).attr("scope").split(' '));
+    }
+
     var p = window.swaggerUi.api.authSchemes;
     for (var key in p) {
       if (p.hasOwnProperty(key)) {
@@ -85,24 +94,24 @@ function handleLogin() {
           if(o.hasOwnProperty(t) && t === 'implicit') {
             var dets = o[t];
             url = dets.loginEndpoint.url + "?response_type=token";
+            if (scopes.indexOf("openid") != -1) {
+                url = dets.loginEndpoint.url + "?response_type=id_token token";
+            }
             window.swaggerUi.tokenName = dets.tokenName;
           }
         }
       }
     }
-    var scopes = []
-    var o = $('.api-popup-scopes').find('input:checked');
 
-    for(k =0; k < o.length; k++) {
-      scopes.push($(o[k]).attr("scope"));
-    }
 
     window.enabledScopes=scopes;
 
     url += '&redirect_uri=' + encodeURIComponent(redirectUrl);
     url += '&realm=' + encodeURIComponent(realm);
     url += '&client_id=' + encodeURIComponent(clientId);
-    url += '&scope=' + encodeURIComponent(scopes);
+    url += '&scope=' + encodeURIComponent(scopes.join(' '));
+    url += '&nonce=' + encodeURIComponent(nonce);
+    url += '&state=' + encodeURIComponent(state);
 
     window.open(url);
   });
@@ -134,7 +143,9 @@ function initOAuth(opts) {
   popupMask = (o.popupMask||$('#api-common-mask'));
   popupDialog = (o.popupDialog||$('.api-popup-dialog'));
   clientId = (o.clientId||errors.push("missing client id"));
-  realm = (o.realm||errors.push("missing realm"));
+  realm = (o.realm || errors.push("missing realm"));
+  state = o.state;
+  nonce = o.nonce;
 
   if(errors.length > 0){
     log("auth unable initialize oauth: " + errors);

--- a/Swashbuckle.Tests/SwaggerUi/SwaggerUiTests.cs
+++ b/Swashbuckle.Tests/SwaggerUi/SwaggerUiTests.cs
@@ -128,5 +128,20 @@ namespace Swashbuckle.Tests.SwaggerUi
             StringAssert.Contains("oAuth2Realm: \"test-realm\"", content);
             StringAssert.Contains("oAuth2AppName: \"test-app-name\"", content);
         }
+
+        [Test]
+        public void It_should_support_an_optional_setting_to_enable_oauth2_OpenID_Connect()
+        {
+            _swaggerUiConfig.EnableOAuth2Support("test-client-id", "test-realm", "test-app-name","test-state","test-nonce");
+
+            var content = GetAsString("http://tempuri.org/swagger/ui/index.html");
+
+            StringAssert.Contains("oAuth2Enabled: true", content);
+            StringAssert.Contains("oAuth2ClientId: \"test-client-id\"", content);
+            StringAssert.Contains("oAuth2Realm: \"test-realm\"", content);
+            StringAssert.Contains("oAuth2AppName: \"test-app-name\"", content);
+            StringAssert.Contains("oAuth2State: \"test-state\"", content);
+            StringAssert.Contains("oAuth2Nonce: \"test-nonce\"", content);
+        }
     }
 }


### PR DESCRIPTION
When the openid scope is included under swaggerSpecConfig authorization, the client script request will set respond type to "id_token token".  OAuth2 server will then respond with access_token and id_token which can be used by client application to make secondary request for user authorization base on user claims.