### PR TITLE
Filter custom model bound action parameters from the list of parameters

### DIFF
--- a/Swashbuckle.Core/Swagger/OperationGenerator.cs
+++ b/Swashbuckle.Core/Swagger/OperationGenerator.cs
@@ -21,7 +21,14 @@ namespace Swashbuckle.Swagger
         {
             var apiPath = apiDescription.RelativePathSansQueryString();
             var parameters = apiDescription.ParameterDescriptions
-                .Where(paramDesc => !(paramDesc.ParameterDescriptor.ParameterBinderAttribute.GetType() == typeof(ModelBinderAttribute)))
+                .Where(paramDesc =>
+                       {
+                           var isCustomModelBoundParameter =
+                               paramDesc.ParameterDescriptor != null &&
+                               paramDesc.ParameterDescriptor.ParameterBinderAttribute != null &&
+                               paramDesc.ParameterDescriptor.ParameterBinderAttribute.GetType() == typeof (ModelBinderAttribute);
+                           return !isCustomModelBoundParameter;
+                       })
                 .Select(paramDesc => CreateParameter(paramDesc, apiPath))
                 .ToList();
 


### PR DESCRIPTION
Removes the action method arguments that are bound by custom model binders from the API endpoint parameters. These parameters could be hashed together from different value providers.
