### PR TITLE
Added a configuration delegate to ignore some endpoints in the index

### DIFF
--- a/Swashbuckle.Core/Application/SwaggerSpecConfig.cs
+++ b/Swashbuckle.Core/Application/SwaggerSpecConfig.cs
@@ -29,6 +29,7 @@ namespace Swashbuckle.Application
         private readonly List<PolymorphicType> _polymorphicTypes;
         private readonly List<Func<IModelFilter>> _modelFilterFactories;
         private readonly List<Func<IOperationFilter>> _operationFilterFactories;
+        private Func<ApiDescription, bool> _shouldIgnoreResolver;
 
         private Info _apiInfo;
         private IDictionary<string, Authorization> _authorizations { get; set; }
@@ -37,7 +38,7 @@ namespace Swashbuckle.Application
         public SwaggerSpecConfig()
         {
             BasePathResolver = (req) => req.RequestUri.GetLeftPart(UriPartial.Authority) + req.GetConfiguration().VirtualPathRoot.TrimEnd('/');
-            ShouldIgnoreResolver = (desc) => true;
+            _shouldIgnoreResolver = (desc) => false;
             Versions = null; 
 
             _targetVersionResolver = (req) => "1.0"; // obsolete
@@ -53,7 +54,6 @@ namespace Swashbuckle.Application
         }
 
         internal Func<HttpRequestMessage, string> BasePathResolver { get; private set; }
-        internal Func<ApiDescription, bool> ShouldIgnoreResolver { get; private set; }
 
         internal IEnumerable<string> Versions { get; private set; }
 
@@ -65,11 +65,11 @@ namespace Swashbuckle.Application
             return this;
         }
 
-        public SwaggerSpecConfig ResolverShouldIgnoreWith(Func<ApiDescription, bool> ignoreResolver)
+        public SwaggerSpecConfig IgnoreActionsWhere(Func<ApiDescription, bool> ignoreResolver)
         {
             if (ignoreResolver == null)
                 throw new ArgumentNullException("ignoreResolver");
-            ShouldIgnoreResolver = ignoreResolver;
+            _shouldIgnoreResolver = ignoreResolver;
             return this;
         }
 
@@ -207,7 +207,7 @@ namespace Swashbuckle.Application
             var apiDescriptions = swaggerRequest.GetConfiguration().Services.GetApiExplorer()
                 .ApiDescriptions
                 .Where(apiDesc => !_ignoreObsoleteActions || apiDesc.IsNotObsolete())
-                .Where(apiDesc => ShouldIgnoreResolver(apiDesc))
+                .Where(apiDesc => !_shouldIgnoreResolver(apiDesc))
                 .Where(apiDesc => _versionSupportResolver(apiDesc, targetVersion));
 
             var options = new SwaggerGeneratorOptions(

--- a/Swashbuckle.Tests/SwaggerSpec/CoreTests.cs
+++ b/Swashbuckle.Tests/SwaggerSpec/CoreTests.cs
@@ -335,8 +335,8 @@ namespace Swashbuckle.Tests.SwaggerSpec
             var declaration = Get<JObject>("http://tempuri.org/swagger/api-docs/ObsoleteActions");
             Assert.IsNotNull(declaration.SelectToken("apis[0].operations[1]"));
             
-            Func<System.Web.Http.Description.ApiDescription, bool> ignoreFunc = (api) => !api.ActionDescriptor.GetCustomAttributes<ObsoleteAttribute>().Any();
-            _swaggerSpecConfig.ResolverShouldIgnoreWith(ignoreFunc);
+            Func<System.Web.Http.Description.ApiDescription, bool> ignoreFunc = (api) => api.ActionDescriptor.GetCustomAttributes<ObsoleteAttribute>().Any();
+            _swaggerSpecConfig.IgnoreActionsWhere(ignoreFunc);
 
             declaration = Get<JObject>("http://tempuri.org/swagger/api-docs/ObsoleteActions");
             Assert.IsNull(declaration.SelectToken("apis[0].operations[1]"));


### PR DESCRIPTION
Add a new method on SwaggerSpecConfig which allows the end user to specify an arbitrary delegate which is used to determine whether or not an endpoint should be included in the index.  Includes a new test for this feature.
