### PR TITLE
Added support for complex types in [FromUri] in Swashbuckle version 4

### DIFF
--- a/Swashbuckle.Core/Application/SwaggerSpecConfig.cs
+++ b/Swashbuckle.Core/Application/SwaggerSpecConfig.cs
@@ -48,7 +48,7 @@ namespace Swashbuckle.Application
             _customTypeMappings = new Dictionary<Type, Func<DataType>>();
             _polymorphicTypes = new List<PolymorphicType>();
             _modelFilterFactories = new List<Func<IModelFilter>>();
-            _operationFilterFactories = new List<Func<IOperationFilter>>();
+            _operationFilterFactories = new List<Func<IOperationFilter>> { () => new HandleComplexTypesFromUri() };
         }
 
         internal Func<HttpRequestMessage, string> BasePathResolver { get; private set; }

--- a/Swashbuckle.Core/SwaggerExtensions/HandleComplexTypesFromUri.cs
+++ b/Swashbuckle.Core/SwaggerExtensions/HandleComplexTypesFromUri.cs
@@ -1,0 +1,47 @@
+﻿using System.Linq;
+using System.Web.Http.Description;
+using Swashbuckle.Swagger;
+
+namespace Swashbuckle.SwaggerExtensions
+{
+    public class HandleComplexTypesFromUri : IOperationFilter
+    {
+        public void Apply(Operation operation, DataTypeRegistry dataTypeRegistry, ApiDescription apiDescription)
+        {
+            if(operation.Parameters == null) 
+                return;
+
+            var models = dataTypeRegistry.GetModels();
+            var complexParameters = operation.Parameters.Where(x => x.ParamType == "query" && !string.IsNullOrWhiteSpace(x.Name) && models.ContainsKey(x.Type)).ToArray();
+            foreach (var parameter in complexParameters)
+            {
+                var model = models[parameter.Type];
+
+                int indexOfParam = operation.Parameters.IndexOf(parameter);
+                operation.Parameters.RemoveAt(indexOfParam);
+   
+                var paramsToAdd = model.Properties.Select(x => new Parameter
+                {
+                    Name = x.Key,
+                    Description = x.Value.Description,
+                    Type = x.Value.Type,
+                    Format = x.Value.Format,
+                    Items = x.Value.Items,
+                    UniqueItems = x.Value.UniqueItems,
+                    Ref = x.Value.Ref,
+                    ParamType = "query",
+                    Enum = x.Value.Enum,
+                    Required = model.Required.Contains(x.Key)
+                })
+                .OrderBy(group => group.ParamType);
+
+                foreach (var newParam in paramsToAdd)
+                {
+                    // insert parameters back in the same spot they were removed
+                    operation.Parameters.Insert(indexOfParam, newParam);
+                    indexOfParam++;
+                }
+            }
+        }
+    }
+}

--- a/Swashbuckle.Core/Swashbuckle.Core.csproj
+++ b/Swashbuckle.Core/Swashbuckle.Core.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ApiDescriptionExtensions.cs" />
     <Compile Include="DictionaryExtensions.cs" />
+    <Compile Include="SwaggerExtensions\HandleComplexTypesFromUri.cs" />
     <Compile Include="Swagger\SwaggerGenerator.cs" />
     <Compile Include="SwaggerExtensions\ApplyActionXmlComments.cs" />
     <Compile Include="SwaggerExtensions\ApplyTypeXmlComments.cs" />

--- a/Swashbuckle.Dummy.Core/Controllers/ParamsFromUriController.cs
+++ b/Swashbuckle.Dummy.Core/Controllers/ParamsFromUriController.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Web.Http;
+
+namespace Swashbuckle.Dummy.Controllers
+{
+    public class ParamsFromUriController : ApiController
+    {
+        [HttpGet]
+        public decimal CalculateTax([FromUri]Address address, [FromUri]Transaction transaction)
+        {
+            throw new NotImplementedException();
+        }
+
+        [HttpHead]
+        public bool SupportsCurrencies([FromUri]IEnumerable<string> currencies)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class Address
+    {
+        public string City { get; set; }
+
+        public string State { get; set; }
+
+        public string Zip { get; set; }
+    }
+
+    public class Transaction
+    {
+        public string Currency { get; set; }
+
+        [Required]
+        public decimal Amount { get; set; }
+
+        public TransactionType TransType { get; set; }
+    }
+
+    public enum TransactionType
+    {
+        TRANSFER,
+        NETWORK
+    }
+}

--- a/Swashbuckle.Dummy.Core/Swashbuckle.Dummy.Core.csproj
+++ b/Swashbuckle.Dummy.Core/Swashbuckle.Dummy.Core.csproj
@@ -60,6 +60,7 @@
   <ItemGroup>
     <Compile Include="Controllers\CollectionOfPrimitivesController.cs" />
     <Compile Include="Controllers\MultipleApiVersionsController.cs" />
+    <Compile Include="Controllers\ParamsFromUriController.cs" />
     <Compile Include="Controllers\SelfReferencingTypesController.cs" />
     <Compile Include="Controllers\CustomersController.cs" />
     <Compile Include="Controllers\DynamicTypesController.cs" />

--- a/Swashbuckle.Tests/SwaggerSpec/CoreTests.cs
+++ b/Swashbuckle.Tests/SwaggerSpec/CoreTests.cs
@@ -262,7 +262,7 @@ namespace Swashbuckle.Tests.SwaggerSpec
                                     responseMessages = new object[]{},
                                     produces = new []{ "application/json", "text/json", "application/xml", "text/xml" },
                                     consumes = new object[]{},
-                                    type = "Product",
+                                    type = "Product"
                                 }
                            }
                         },
@@ -428,6 +428,66 @@ namespace Swashbuckle.Tests.SwaggerSpec
 
             Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
         }
+
+        [Test]
+        public void It_handles_complex_and_array_params_from_uri()
+        {
+            SetUpDefaultRouteFor<ParamsFromUriController>();
+
+            var declarationParams = Get<JObject>("http://tempuri.org/swagger/api-docs/ParamsFromUri")
+                .SelectToken("apis[0].operations[0].parameters");
+
+            var expectedParams = JArray.FromObject(new object[]
+            {
+                new
+                {
+                    paramType = "query",
+                    name = "City",
+                    required = false,
+                    type = "string"
+                },
+                new
+                {
+                    paramType = "query",
+                    name = "State",
+                    required = false,
+                    type = "string"
+                },
+                new
+                {
+                   paramType = "query",
+                   name = "Zip",
+                   required = false,
+                   type = "string"
+                },
+                new
+                {
+                    paramType = "query",
+                    name = "Currency",
+                    required = false,
+                    type = "string"
+                },
+                new
+                {
+                    paramType = "query",
+                    name = "Amount",
+                    required = true,
+                    type = "number",
+                    format = "double"
+                },
+                new 
+                {
+                    paramType = "query",
+                    name = "TransType",
+                    required = false,
+                    type = "string",
+                    @enum = new[] { "TRANSFER", "NETWORK" }
+                }
+            });
+
+            Assert.AreEqual(expectedParams.ToString(), declarationParams.ToString());
+        }
+
 
         class AddResponseCodes : IOperationFilter
         {


### PR DESCRIPTION
I can't support Swagger 2.0 yet.  I needed this fix in Swashbuckle version 4, so backported the changes from #70.