### PR TITLE
Using interface XML docs for controller actions

### DIFF
--- a/Swashbuckle.Dummy.Core/Controllers/ExternallyDocumentedController.cs
+++ b/Swashbuckle.Dummy.Core/Controllers/ExternallyDocumentedController.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Web.Http;
+
+namespace Swashbuckle.Dummy.Controllers
+{
+    public interface IExternallyDocumentedController
+    {
+        /// <summary>
+        /// This summary is defined on interface level
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        int GetSimpleValue(int id);
+
+        /// <summary>
+        /// This summary is defined on interface level and will be overriden on implementation
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="value"></param>
+        void SetSimpleValue(int id, int value);
+    }
+
+    public class ExternallyDocumentedController : ApiController, IExternallyDocumentedController
+    {
+        public int GetSimpleValue(int id)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// This summary is defined on instance and overrides interface
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="value"></param>
+        public void SetSimpleValue(int id, int value)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Swashbuckle.Dummy.Core/Swashbuckle.Dummy.Core.csproj
+++ b/Swashbuckle.Dummy.Core/Swashbuckle.Dummy.Core.csproj
@@ -59,6 +59,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Controllers\CollectionOfPrimitivesController.cs" />
+    <Compile Include="Controllers\ExternallyDocumentedController.cs" />
     <Compile Include="Controllers\MultipleApiVersionsController.cs" />
     <Compile Include="Controllers\SelfReferencingTypesController.cs" />
     <Compile Include="Controllers\CustomersController.cs" />

--- a/Swashbuckle.Dummy.Core/XmlComments.xml
+++ b/Swashbuckle.Dummy.Core/XmlComments.xml
@@ -4,6 +4,27 @@
         <name>Swashbuckle.Dummy.Core</name>
     </assembly>
     <members>
+        <member name="M:Swashbuckle.Dummy.Controllers.IExternallyDocumentedController.GetSimpleValue(System.Int32)">
+            <summary>
+            This summary is defined on interface level
+            </summary>
+            <param name="id"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Swashbuckle.Dummy.Controllers.IExternallyDocumentedController.SetSimpleValue(System.Int32,System.Int32)">
+            <summary>
+            This summary is defined on interface level and will be overriden on implementation
+            </summary>
+            <param name="id"></param>
+            <param name="value"></param>
+        </member>
+        <member name="M:Swashbuckle.Dummy.Controllers.ExternallyDocumentedController.SetSimpleValue(System.Int32,System.Int32)">
+            <summary>
+            This summary is defined on instance and overrides interface
+            </summary>
+            <param name="id"></param>
+            <param name="value"></param>
+        </member>
         <member name="M:Swashbuckle.Dummy.Controllers.ProductsController.Create(Swashbuckle.Dummy.Controllers.Product)">
             <summary>
             Create a new product 

--- a/Swashbuckle.Dummy.WebHost/XmlComments.xml
+++ b/Swashbuckle.Dummy.WebHost/XmlComments.xml
@@ -4,6 +4,27 @@
         <name>Swashbuckle.Dummy.Core</name>
     </assembly>
     <members>
+        <member name="M:Swashbuckle.Dummy.Controllers.IExternallyDocumentedController.GetSimpleValue(System.Int32)">
+            <summary>
+            This summary is defined on interface level
+            </summary>
+            <param name="id"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Swashbuckle.Dummy.Controllers.IExternallyDocumentedController.SetSimpleValue(System.Int32,System.Int32)">
+            <summary>
+            This summary is defined on interface level and will be overriden on implementation
+            </summary>
+            <param name="id"></param>
+            <param name="value"></param>
+        </member>
+        <member name="M:Swashbuckle.Dummy.Controllers.ExternallyDocumentedController.SetSimpleValue(System.Int32,System.Int32)">
+            <summary>
+            This summary is defined on instance and overrides interface
+            </summary>
+            <param name="id"></param>
+            <param name="value"></param>
+        </member>
         <member name="M:Swashbuckle.Dummy.Controllers.ProductsController.Create(Swashbuckle.Dummy.Controllers.Product)">
             <summary>
             Create a new product 

--- a/Swashbuckle.Tests/SwaggerSpec/XmlCommentsTests.cs
+++ b/Swashbuckle.Tests/SwaggerSpec/XmlCommentsTests.cs
@@ -3,10 +3,6 @@ using NUnit.Framework;
 using Swashbuckle.Application;
 using Swashbuckle.Dummy.Controllers;
 using System;
-using System.Net.Http;
-using System.Web.Http;
-using System.Web.Http.Hosting;
-using System.Web.Http.Routing;
 
 namespace Swashbuckle.Tests.SwaggerSpec
 {
@@ -100,5 +96,28 @@ namespace Swashbuckle.Tests.SwaggerSpec
             Assert.IsNotNull(token);
             Assert.AreEqual("Uniquely identifies the product", token.ToString());
         }
+
+        [Test]
+        public void It_should_use_interface_doc_when_no_own_doc_available()
+        {
+            SetUpDefaultRouteFor<ExternallyDocumentedController>();
+            var declaration = Get<JObject>("http://tempuri.org/swagger/api-docs/ExternallyDocumented");
+
+            var token = declaration.SelectToken("apis[0].operations[0].summary");
+            Assert.IsNotNull(token);
+            Assert.AreEqual("This summary is defined on interface level", token.ToString());
+        }
+
+        [Test]
+        public void It_should_override_interface_doc_when_own_doc_available()
+        {
+            SetUpDefaultRouteFor<ExternallyDocumentedController>();
+            var declaration = Get<JObject>("http://tempuri.org/swagger/api-docs/ExternallyDocumented");
+
+            var token = declaration.SelectToken("apis[0].operations[1].summary");
+            Assert.IsNotNull(token);
+            Assert.AreEqual("This summary is defined on instance and overrides interface", token.ToString());
+        }
+
     }
 }


### PR DESCRIPTION
Currently, Swashbuckle is unable to use XML docs for actions which are defined and documented in interfaces. 

This pull requests adds ability to read XML docs for method definition in the interfaces. It also leaves possibility to override interface's XML doc by defining it on controller level