### PR TITLE
Updated ApplyXmlTypeComments to pull Property comments from base classes

### DIFF
--- a/Swashbuckle.Core/Swagger/Filters/ApplyXmlTypeComments.cs
+++ b/Swashbuckle.Core/Swagger/Filters/ApplyXmlTypeComments.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Xml.XPath;
 using Swashbuckle.Swagger;
+using System.Collections.Generic;
 
 namespace Swashbuckle.Swagger.Filters
 {
@@ -26,9 +27,22 @@ namespace Swashbuckle.Swagger.Filters
             if (summaryNode != null)
                 schema.description = summaryNode.Value.Trim();
 
+            List<Type> typeList = new List<Type>();
+            typeList.Add(type);
+            while (typeList[typeList.Count - 1].BaseType != null)
+            {
+                typeList.Add(typeList[typeList.Count - 1].BaseType);
+            }
+
             foreach (var property in schema.properties)
             {
-                var propertyNode = _navigator.SelectSingleNode(String.Format(PropertyExpression, type.FullName, property.Key));
+                XPathNavigator propertyNode = null;
+
+                foreach (Type t in typeList)
+                {
+                    propertyNode = _navigator.SelectSingleNode(String.Format(PropertyExpression, t.FullName, property.Key));
+                    if (propertyNode != null) { break; }
+                }
                 if (propertyNode != null)
                     property.Value.description = propertyNode.Value.Trim();
             }

--- a/Swashbuckle.Core/Swagger/Filters/ApplyXmlTypeComments.cs
+++ b/Swashbuckle.Core/Swagger/Filters/ApplyXmlTypeComments.cs
@@ -44,7 +44,13 @@ namespace Swashbuckle.Swagger.Filters
                     if (propertyNode != null) { break; }
                 }
                 if (propertyNode != null)
-                    property.Value.description = propertyNode.Value.Trim();
+                {
+                    XPathNavigator propSummaryNode = propertyNode.SelectSingleNode(SummaryExpression);
+                    if (propSummaryNode != null)
+                    {
+                        property.Value.description = propSummaryNode.Value.Trim();
+                    }
+                }
             }
         }
     }

--- a/Swashbuckle.Dummy.Core/Controllers/XmlAnnotatedController.cs
+++ b/Swashbuckle.Dummy.Core/Controllers/XmlAnnotatedController.cs
@@ -17,6 +17,15 @@ namespace Swashbuckle.Dummy.Controllers
         }
 
         /// <summary>
+        /// Updates a SubAccount.
+        /// </summary>
+        [HttpPut]
+        public int UpdateSubAccount(SubAccount account)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
         /// Search all registered accounts by keywords 
         /// </summary>
         /// <remarks>Restricted to admin users only</remarks>
@@ -35,6 +44,11 @@ namespace Swashbuckle.Dummy.Controllers
     public class Account
     {
         /// <summary>
+        /// The ID for Accounts is 5 digits long.
+        /// </summary>
+        public virtual int AccountID { get; set; }
+        
+        /// <summary>
         /// Uniquely identifies the account
         /// </summary>
         public string Username { get; set; }
@@ -43,5 +57,18 @@ namespace Swashbuckle.Dummy.Controllers
         /// For authentication
         /// </summary>
         public string Password { get; set; }
+    }
+
+    /// <summary>
+    /// A Sub-Type of Account
+    /// </summary>
+    public class SubAccount : Account
+    {
+
+        /// <summary>
+        /// The Account ID for SubAccounts should be 7 digits.
+        /// </summary>
+        public override int AccountID { get; set; }
+
     }
 }

--- a/Swashbuckle.Dummy.Core/XmlComments.xml
+++ b/Swashbuckle.Dummy.Core/XmlComments.xml
@@ -11,6 +11,11 @@
             <remarks>Create an account to access restricted resources</remarks>
             <param name="account">Details for the account to be created</param>
         </member>
+        <member name="M:Swashbuckle.Dummy.Controllers.XmlAnnotatedController.UpdateSubAccount(Swashbuckle.Dummy.Controllers.SubAccount)">
+            <summary>
+            Updates a SubAccount.
+            </summary>
+        </member>
         <member name="M:Swashbuckle.Dummy.Controllers.XmlAnnotatedController.Search(System.Collections.Generic.IEnumerable{System.String})">
             <summary>
             Search all registered accounts by keywords 
@@ -24,6 +29,11 @@
             Account details
             </summary>
         </member>
+        <member name="P:Swashbuckle.Dummy.Controllers.Account.AccountID">
+            <summary>
+            The ID for Accounts is 5 digits long.
+            </summary>
+        </member>
         <member name="P:Swashbuckle.Dummy.Controllers.Account.Username">
             <summary>
             Uniquely identifies the account
@@ -32,6 +42,16 @@
         <member name="P:Swashbuckle.Dummy.Controllers.Account.Password">
             <summary>
             For authentication
+            </summary>
+        </member>
+        <member name="T:Swashbuckle.Dummy.Controllers.SubAccount">
+            <summary>
+            A Sub-Type of Account
+            </summary>
+        </member>
+        <member name="P:Swashbuckle.Dummy.Controllers.SubAccount.AccountID">
+            <summary>
+            The Account ID for SubAccounts should be 7 digits.
             </summary>
         </member>
     </members>

--- a/Swashbuckle.Dummy.WebHost/XmlComments.xml
+++ b/Swashbuckle.Dummy.WebHost/XmlComments.xml
@@ -11,6 +11,11 @@
             <remarks>Create an account to access restricted resources</remarks>
             <param name="account">Details for the account to be created</param>
         </member>
+        <member name="M:Swashbuckle.Dummy.Controllers.XmlAnnotatedController.UpdateSubAccount(Swashbuckle.Dummy.Controllers.SubAccount)">
+            <summary>
+            Updates a SubAccount.
+            </summary>
+        </member>
         <member name="M:Swashbuckle.Dummy.Controllers.XmlAnnotatedController.Search(System.Collections.Generic.IEnumerable{System.String})">
             <summary>
             Search all registered accounts by keywords 
@@ -24,6 +29,11 @@
             Account details
             </summary>
         </member>
+        <member name="P:Swashbuckle.Dummy.Controllers.Account.AccountID">
+            <summary>
+            The ID for Accounts is 5 digits long.
+            </summary>
+        </member>
         <member name="P:Swashbuckle.Dummy.Controllers.Account.Username">
             <summary>
             Uniquely identifies the account
@@ -32,6 +42,16 @@
         <member name="P:Swashbuckle.Dummy.Controllers.Account.Password">
             <summary>
             For authentication
+            </summary>
+        </member>
+        <member name="T:Swashbuckle.Dummy.Controllers.SubAccount">
+            <summary>
+            A Sub-Type of Account
+            </summary>
+        </member>
+        <member name="P:Swashbuckle.Dummy.Controllers.SubAccount.AccountID">
+            <summary>
+            The Account ID for SubAccounts should be 7 digits.
             </summary>
         </member>
     </members>

--- a/Swashbuckle.Tests/Swagger/XmlCommentsTests.cs
+++ b/Swashbuckle.Tests/Swagger/XmlCommentsTests.cs
@@ -76,5 +76,29 @@ namespace Swashbuckle.Tests.Swagger
             Assert.IsNotNull(passwordProperty["description"]);
             Assert.AreEqual("For authentication", passwordProperty["description"].ToString());
         }
+
+        [Test]
+        public void It_documents_schema_properties_from_property_summay_tags_of_base_classes()
+        {
+            var swagger = GetContent<JObject>("http://tempuri.org/swagger/docs/1.0");
+
+            var usernameProperty = swagger["definitions"]["SubAccount"]["properties"]["Username"];
+            Assert.IsNotNull(usernameProperty["description"]);
+            Assert.AreEqual("Uniquely identifies the account", usernameProperty["description"].ToString());
+        }
+
+        /// <summary>
+        /// This test checks that Swashbuckle uses the derived class's comments rather than the base
+        /// class's comments when generating descriptions for properties that have been overridden.
+        /// </summary>
+        [Test]
+        public void It_documents_schema_properties_using_derived_class_summary_tags()
+        {
+            var swagger = GetContent<JObject>("http://tempuri.org/swagger/docs/1.0");
+
+            var usernameProperty = swagger["definitions"]["SubAccount"]["properties"]["AccountID"];
+            Assert.IsNotNull(usernameProperty["description"]);
+            Assert.AreEqual("The Account ID for SubAccounts should be 7 digits.", usernameProperty["description"].ToString());
+        }
     }
 }


### PR DESCRIPTION
Derived classes were not getting descriptions for properties that came from a base class. I updated ApplyXmlTypeComments to pull the comments from base classes.