### PR TITLE
Add ability to hide model fields that are [Obsolete]

### DIFF
--- a/Swashbuckle.Core/Application/SwaggerSpecConfig.cs
+++ b/Swashbuckle.Core/Application/SwaggerSpecConfig.cs
@@ -166,6 +166,11 @@ namespace Swashbuckle.Application
             return this;
         }
 
+        public SwaggerSpecConfig IgnoreObsoleteModelFields()
+        {
+            return ModelFilter<HideObsoleteModelFields>();
+        }
+
         public SwaggerSpecConfig OperationFilter<T>()
             where T : IOperationFilter, new()
         {
@@ -182,8 +187,7 @@ namespace Swashbuckle.Application
         public SwaggerSpecConfig IncludeXmlComments(string xmlCommentsPath)
         {
             _operationFilterFactories.Add(() => new ApplyActionXmlComments(xmlCommentsPath));
-            _modelFilterFactories.Add(() => new ApplyTypeXmlComments(xmlCommentsPath));
-            return this;
+            return ModelFilter(new ApplyTypeXmlComments(xmlCommentsPath));
         }
 
         public SwaggerSpecConfig ApiInfo(Info apiInfo)

--- a/Swashbuckle.Core/SwaggerExtensions/HideObsoleteModelFields.cs
+++ b/Swashbuckle.Core/SwaggerExtensions/HideObsoleteModelFields.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Linq;
+using Swashbuckle.Swagger;
+
+namespace Swashbuckle.SwaggerExtensions
+{
+    class HideObsoleteModelFields : IModelFilter
+    {
+        public void Apply(DataType model, DataTypeRegistry dataTypeRegistry, Type type)
+        {
+            foreach (
+                var name in
+                    from name in model.Properties.Keys.ToArray()
+                    let property = type.GetProperty(name)
+                    where property != null && property.GetCustomAttributes(typeof(ObsoleteAttribute), false).Any()
+                    select name)
+            {
+                model.Properties.Remove(name);
+            }
+        }
+    }
+}

--- a/Swashbuckle.Core/Swashbuckle.Core.csproj
+++ b/Swashbuckle.Core/Swashbuckle.Core.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ApiDescriptionExtensions.cs" />
     <Compile Include="DictionaryExtensions.cs" />
+    <Compile Include="SwaggerExtensions\HideObsoleteModelFields.cs" />
     <Compile Include="Swagger\SwaggerGenerator.cs" />
     <Compile Include="SwaggerExtensions\ApplyActionXmlComments.cs" />
     <Compile Include="SwaggerExtensions\ApplyTypeXmlComments.cs" />

--- a/Swashbuckle.Dummy.Core/Controllers/ObsoleteModelFieldsController.cs
+++ b/Swashbuckle.Dummy.Core/Controllers/ObsoleteModelFieldsController.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Web.Http;
+
+namespace Swashbuckle.Dummy.Controllers
+{
+    public class ObsoleteModelFieldsController : ApiController
+    {
+        static int _generatedId;
+
+        public int Create(CreateEntityForm form)
+        {
+            return _generatedId++;
+        }
+    }
+    
+    public class CreateEntityForm
+    {
+        [Obsolete("We switched to generated ids -- clients should only provide Name")]
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+    }
+}

--- a/Swashbuckle.Dummy.Core/Swashbuckle.Dummy.Core.csproj
+++ b/Swashbuckle.Dummy.Core/Swashbuckle.Dummy.Core.csproj
@@ -60,6 +60,7 @@
   <ItemGroup>
     <Compile Include="Controllers\CollectionOfPrimitivesController.cs" />
     <Compile Include="Controllers\CustomActionNamesController.cs" />
+    <Compile Include="Controllers\ObsoleteModelFieldsController.cs" />
     <Compile Include="Controllers\MultipleApiVersionsController.cs" />
     <Compile Include="Controllers\SelfReferencingTypesController.cs" />
     <Compile Include="Controllers\CustomersController.cs" />

--- a/Swashbuckle.Tests/SwaggerSpec/ModelTests.cs
+++ b/Swashbuckle.Tests/SwaggerSpec/ModelTests.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Linq;
+using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using Swashbuckle.Application;
 using Swashbuckle.Dummy.Controllers;
@@ -358,6 +359,28 @@ namespace Swashbuckle.Tests.SwaggerSpec
                 .SelectToken("models");
 
             Assert.AreEqual("foobar", models.SelectToken("Product.description").ToString());
+        }
+
+        [Test]
+        public void It_should_support_ignoring_model_fields_marked_obsolete()
+        {
+            SetUpDefaultRouteFor<ObsoleteModelFieldsController>();
+
+            var properties = Get<JObject>("http://tempuri.org/swagger/api-docs/ObsoleteModelFields")
+                .SelectToken("models.CreateEntityForm.properties");
+
+            Assert.AreEqual(2, properties.Children().Count());
+            Assert.IsNotNull(properties["Id"]);
+            Assert.IsNotNull(properties["Name"]);
+
+            _swaggerSpecConfig.IgnoreObsoleteModelFields();
+
+            properties = Get<JObject>("http://tempuri.org/swagger/api-docs/ObsoleteModelFields")
+                .SelectToken("models.CreateEntityForm.properties");
+
+            Assert.AreEqual(1, properties.Children().Count());
+            Assert.IsNull(properties["Id"]);
+            Assert.IsNotNull(properties["Name"]);
         }
 
         class OverrideDescription : IModelFilter


### PR DESCRIPTION
A common occurrence as APIs evolve is to mark model fields `[Obsolete]`.

We usually retain the prior fields for backwards compatibility (sometimes just for a small migration window), but we don't want to advertize them in documentation.

This is opt-**in** behavior, (`c.IgnoreObsoleteModelFields()`)