### PR TITLE
allowing the ability to force the use of string enums

### DIFF
--- a/Swashbuckle.Core/Application/SwaggerDocsConfig.cs
+++ b/Swashbuckle.Core/Application/SwaggerDocsConfig.cs
@@ -23,6 +23,7 @@ namespace Swashbuckle.Application
         private readonly IList<Func<IOperationFilter>> _operationFilters;
         private readonly IList<Func<IDocumentFilter>> _documentFilters;
         private Func<IEnumerable<ApiDescription>, ApiDescription> _conflictingActionsResolver;
+        private Func<bool> _forceStringEnumConversion;
 
         public SwaggerDocsConfig()
         {
@@ -144,11 +145,16 @@ namespace Swashbuckle.Application
             _conflictingActionsResolver = conflictingActionsResolver;
         }
 
+        public void ForceStringEnumConversion(Func<bool> factory)
+        {
+            _forceStringEnumConversion = factory;
+        }
+
         internal Func<HttpRequestMessage, string> GetRootUrlResolver()
         {
             return _rootUrlResolver;
         }
-
+        
         internal IEnumerable<string> GetApiVersions()
         {
             return _versionInfoBuilder.Build().Select(entry => entry.Key);
@@ -171,7 +177,8 @@ namespace Swashbuckle.Application
                 schemaFilters: _schemaFilters.Select(factory => factory()),
                 operationFilters: _operationFilters.Select(factory => factory()),
                 documentFilters: _documentFilters.Select(factory => factory()),
-                conflictingActionsResolver: _conflictingActionsResolver
+                conflictingActionsResolver: _conflictingActionsResolver,
+                forceStringEnumConversion: _forceStringEnumConversion
             );
         }
 

--- a/Swashbuckle.Core/Swagger/SchemaRegistry.cs
+++ b/Swashbuckle.Core/Swagger/SchemaRegistry.cs
@@ -46,15 +46,19 @@ namespace Swashbuckle.Swagger
         private readonly IContractResolver _contractResolver;
         private readonly IDictionary<Type, Func<Schema>> _customSchemaMappings;
         private readonly IEnumerable<ISchemaFilter> _schemaFilters;
+        private readonly bool _forceStringEnumConversion;
 
         public SchemaRegistry(
             IContractResolver contractResolver,
             IDictionary<Type, Func<Schema>> customSchemaMappings,
-            IEnumerable<ISchemaFilter> schemaFilters)
+            IEnumerable<ISchemaFilter> schemaFilters,
+            bool forceStringEnumConversion
+            )
         {
             _contractResolver = contractResolver;
             _customSchemaMappings = customSchemaMappings;
             _schemaFilters = schemaFilters;
+            _forceStringEnumConversion = forceStringEnumConversion;
 
             Definitions = new Dictionary<string, Schema>(StringComparer.OrdinalIgnoreCase);
         }
@@ -105,6 +109,11 @@ namespace Swashbuckle.Swagger
 
             if (type.IsEnum)
             {
+                if (_forceStringEnumConversion)
+                {
+                    return new Schema { type = "string", @enum = type.GetEnumNames()};
+                }
+
                 var converter = contract.Converter;
                 return (converter != null && converter.GetType() == typeof(StringEnumConverter))
                     ? new Schema { type = "string", @enum = type.GetEnumNames() }

--- a/Swashbuckle.Core/Swagger/SwaggerGenerator.cs
+++ b/Swashbuckle.Core/Swagger/SwaggerGenerator.cs
@@ -28,7 +28,12 @@ namespace Swashbuckle.Swagger
 
         public SwaggerDocument GetSwaggerFor(string apiVersion)
         {
-            var schemaRegistry = new SchemaRegistry(_jsonContractResolver, _settings.CustomSchemaMappings, _settings.SchemaFilters);
+            bool forceStringEnum = false;
+            if (_settings.ForceStringEnumConversion != null)
+            {
+                forceStringEnum = _settings.ForceStringEnumConversion();
+            }
+            var schemaRegistry = new SchemaRegistry(_jsonContractResolver, _settings.CustomSchemaMappings, _settings.SchemaFilters, forceStringEnum);
 
             Info info;
             _settings.ApiVersions.TryGetValue(apiVersion, out info);

--- a/Swashbuckle.Core/Swagger/SwaggerGeneratorSettings.cs
+++ b/Swashbuckle.Core/Swagger/SwaggerGeneratorSettings.cs
@@ -18,12 +18,15 @@ namespace Swashbuckle.Swagger
             IEnumerable<ISchemaFilter> schemaFilters = null,
             IEnumerable<IOperationFilter> operationFilters = null,
             IEnumerable<IDocumentFilter> documentFilters = null,
-            Func<IEnumerable<ApiDescription>, ApiDescription> conflictingActionsResolver = null)
+            Func<IEnumerable<ApiDescription>, ApiDescription> conflictingActionsResolver = null,
+            Func<bool> forceStringEnumConversion = null
+            )
         {
             VersionSupportResolver = versionSupportResolver;
             Schemes = schemes;
             ApiVersions = apiVersions;
             SecurityDefinitions = securityDefinitions;
+            ForceStringEnumConversion = forceStringEnumConversion;
             GroupingKeySelector = groupingKeySelector ?? DefaultGroupingKeySelector;
             GroupingKeyComparer = groupingKeyComparer ?? Comparer<string>.Default;
             CustomSchemaMappings = customSchemaMappings ?? new Dictionary<Type, Func<Schema>>();
@@ -46,6 +49,8 @@ namespace Swashbuckle.Swagger
         public IComparer<string> GroupingKeyComparer { get; private set; }
 
         public IDictionary<Type, Func<Schema>> CustomSchemaMappings { get; private set; }
+
+        public Func<bool> ForceStringEnumConversion { get; private set; }
 
         public IEnumerable<ISchemaFilter> SchemaFilters { get; private set; }
 

--- a/Swashbuckle.Dummy.Core/App_Start/SwaggerConfig.cs
+++ b/Swashbuckle.Dummy.Core/App_Start/SwaggerConfig.cs
@@ -154,6 +154,15 @@ namespace Swashbuckle.Dummy
                         // custom strategy to pick a winner or merge the descriptions for the purposes of the Swagger docs 
                         //
                         c.ResolveConflictingActions(apiDescriptions => apiDescriptions.First());
+
+                        c.ForceStringEnumConversion(() =>
+                        {
+                            // could  check SerializerSettings.Converters for the StringEnumConverter here, I'll just hard code it to true
+                            // because we don't have a reference to the formatters here
+                            // var jsonFormatter = GlobalConfiguration.Configuration.Formatters.JsonFormatter;
+                            // jsonFormatter.SerializerSettings.Converters.Add(new Newtonsoft.Json.Converters.StringEnumConverter());
+                            return true;
+                        });
                     })
                 .EnableSwaggerUi(c =>
                     {

--- a/Swashbuckle.Dummy.WebHost/Global.asax.cs
+++ b/Swashbuckle.Dummy.WebHost/Global.asax.cs
@@ -7,9 +7,10 @@ namespace Swashbuckle.Dummy.WebHost
     {
         protected void Application_Start()
         {
-            SwaggerConfig.Register(GlobalConfiguration.Configuration);
-            
+            SwaggerConfig.Register(GlobalConfiguration.Configuration);            
             GlobalConfiguration.Configure(WebApiConfig.Register);
+            var jsonFormatter = GlobalConfiguration.Configuration.Formatters.JsonFormatter;
+            jsonFormatter.SerializerSettings.Converters.Add(new Newtonsoft.Json.Converters.StringEnumConverter());
         }
     }
 }


### PR DESCRIPTION
Related to issue #131, we don't have a reference to Json.Net in our models assembly so we've always used 

```
var jsonFormatter = GlobalConfiguration.Configuration.Formatters.JsonFormatter;
jsonFormatter.SerializerSettings.Converters.Add(new Newtonsoft.Json.Converters.StringEnumConverter());
```

to configure the global formatters. Because of that we can't rely on the individual enums having the proper attributes so we need a way to tell swashbuckle how to use it. 

This PR hard codes true for the override, but there shouldn't be a reason the default couldn't be to query the global formatters looking to see if StringEnumConverter is in there.

One note - it seems that once you set StringEnumConverter globally there isn't a good way to force int enums on individual items. That's why I went with the "force global string enum" option name.