### PR TITLE
Return type feature in XML documentation for actions returning HttpResponseMessage

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,13 @@ Although it's not one of the official XML comment tags, Swashbuckle also support
     
 These values will get mapped to the Operation.ResponseMessages.
 
+When HttpResponseMessage is returned from a controller action, Swashbuckle automatically sets the return type to **string**. Swashbuckle does support using the cref attribute on the **returns** element of the xml comment to specify the return type wrapped by the HttpResponseMessage.
+
+	///<returns cref="Product">Gets a specific product</returns>
+	public HttpResponseMessage Get(long id)
+	
+The parsed value will get mapped to the Operation.Type property.
+
 ### Customize the swagger-ui ###
 
 The Swagger UI supports a number of options to customize its appearance and behavior. See the [documentation](https://github.com/wordnik/swagger-ui) for a detailed description.

--- a/README.md
+++ b/README.md
@@ -246,10 +246,10 @@ If you annotate Controllers and API Types with [Xml Comments](http://msdn.micros
 Although it's not one of the official XML comment tags, Swashbuckle also supports the use of one or more **response** tags on an action. These can be used to describe the error codes for a given operation. For example,
 
     /// <response code="200">It's all good!</response>
-    /// <response code="500" cref="Error">Somethings up!</response>
+    /// <response code="500">Somethings up!</response>
     public int Create(Product product)
     
-These values will get mapped to the Operation.ResponseMessages. Response models specific to a status code can be referenced using a cref attribute.
+These values will get mapped to the Operation.ResponseMessages.
 
 When HttpResponseMessage is returned from a controller action, Swashbuckle automatically sets the return type to **string**. Swashbuckle does support using the cref attribute on the **returns** element of the xml comment to specify the return type wrapped by the HttpResponseMessage.
 

--- a/README.md
+++ b/README.md
@@ -246,10 +246,10 @@ If you annotate Controllers and API Types with [Xml Comments](http://msdn.micros
 Although it's not one of the official XML comment tags, Swashbuckle also supports the use of one or more **response** tags on an action. These can be used to describe the error codes for a given operation. For example,
 
     /// <response code="200">It's all good!</response>
-    /// <response code="500">Somethings up!</response>
+    /// <response code="500" cref="Error">Somethings up!</response>
     public int Create(Product product)
     
-These values will get mapped to the Operation.ResponseMessages.
+These values will get mapped to the Operation.ResponseMessages. Response models specific to a status code can be referenced using a cref attribute.
 
 When HttpResponseMessage is returned from a controller action, Swashbuckle automatically sets the return type to **string**. Swashbuckle does support using the cref attribute on the **returns** element of the xml comment to specify the return type wrapped by the HttpResponseMessage.
 

--- a/Swashbuckle.Core/Swagger/SwaggerSpec.cs
+++ b/Swashbuckle.Core/Swagger/SwaggerSpec.cs
@@ -282,9 +282,6 @@ namespace Swashbuckle.Swagger
 
         [JsonProperty("message")]
         public string Message { get; set; }
-
-		[JsonProperty("responseModel")]
-		public string ResponseModel { get; set; }
     }
 
     public class DataType

--- a/Swashbuckle.Core/Swagger/SwaggerSpec.cs
+++ b/Swashbuckle.Core/Swagger/SwaggerSpec.cs
@@ -282,6 +282,9 @@ namespace Swashbuckle.Swagger
 
         [JsonProperty("message")]
         public string Message { get; set; }
+
+		[JsonProperty("responseModel")]
+		public string ResponseModel { get; set; }
     }
 
     public class DataType

--- a/Swashbuckle.Core/SwaggerExtensions/ApplyActionXmlComments.cs
+++ b/Swashbuckle.Core/SwaggerExtensions/ApplyActionXmlComments.cs
@@ -16,8 +16,10 @@ namespace Swashbuckle.SwaggerExtensions
         private const string MethodExpression = "/doc/members/member[@name='M:{0}.{1}{2}']";
         private const string SummaryExpression = "summary";
         private const string RemarksExpression = "remarks";
-        private const string ParameterExpression = "param[@name=\"{0}\"]";
-        private const string ResponseExpression = "response";
+		private const string ParameterExpression = "param[@name=\"{0}\"]";
+		private const string ResponseExpression = "response";
+		private const string TypeNameAttributeExpression = "cref";
+		private const string ReturnsExpression = "returns[@" + TypeNameAttributeExpression + "]";
 
         private readonly XPathNavigator _navigator;
 
@@ -51,7 +53,30 @@ namespace Swashbuckle.SwaggerExtensions
             {
                 operation.ResponseMessages.Add(responseMessage);
             }
+
+			var returnType = GetCustomReturnType(methodNode);
+			if (returnType == null) return;
+
+			var dataType = dataTypeRegistry.GetOrRegister(returnType);
+			operation.Type = dataType.Id;
         }
+
+		private static Type GetCustomReturnType(XPathNavigator methodNode)
+		{
+			var attributeValue = GetAttributeValueOrDefault(methodNode, ReturnsExpression, TypeNameAttributeExpression);
+			if (attributeValue == null || !attributeValue.StartsWith("T:") || attributeValue.Length < 3) return null;
+			var returnTypeName = attributeValue.Substring(2);
+
+			var type = AppDomain
+				.CurrentDomain
+				.GetAssemblies()
+				.Where(a => a != null)
+				.SelectMany(a => a.GetTypes())
+				.Where(t => t != null)
+				.FirstOrDefault(t => t.FullName.Equals(returnTypeName));
+
+			return type;
+		}
 
         private static string GetXPathFor(HttpActionDescriptor actionDescriptor)
         {
@@ -97,13 +122,24 @@ namespace Swashbuckle.SwaggerExtensions
             return type.Namespace + "." + type.Name;
         }
 
-        private static string GetChildValueOrDefault(XPathNavigator node, string childExpression)
-        {
-            if (node == null) return String.Empty;
+		private static string GetChildValueOrDefault(XPathNavigator node, string childExpression)
+		{
+			if (node == null) return String.Empty;
 
-            var childNode = node.SelectSingleNode(childExpression);
-            return (childNode == null) ? String.Empty : childNode.Value.Trim();
-        }
+			var childNode = node.SelectSingleNode(childExpression);
+			return (childNode == null) ? String.Empty : childNode.Value.Trim();
+		}        
+
+		private static string GetAttributeValueOrDefault(XPathNavigator node, string childExpression, string attributeName)
+		{
+			if (node == null) return null;
+
+			var childNode = node.SelectSingleNode(childExpression);
+			if (childNode == null) return null;
+
+			var attribute = childNode.GetAttribute(attributeName, string.Empty);
+			return (attribute == null) ? null : attribute.Trim();
+		}
 
         private static IEnumerable<ResponseMessage> GetResponseMessages(XPathNavigator node)
         {


### PR DESCRIPTION
Since I always use HttpResponseMessage as a return type on my actions in Web APIs, I had the problem of my return type in swagger being **string**.

I added the ability to set the cref attribute on the **returns** element of the xml documentation of an action method to specify the return type.