### PR TITLE
Change DefaultRootUrlResolver to support X-Forwarded headers

### DIFF
--- a/Swashbuckle.Tests/Swagger/CoreTests.cs
+++ b/Swashbuckle.Tests/Swagger/CoreTests.cs
@@ -361,43 +361,11 @@ namespace Swashbuckle.Tests.Swagger
         }
 
         [Test]
-        public void It_exposes_config_to_implicitly_provide_current_scheme()
-        {
-            var swagger = GetContent<JObject>("http://tempuri.org/swagger/docs/1.0");
-            var schemes = swagger["schemes"];
-            var expected = JArray.FromObject(new[] { "http" });
-
-            Assert.AreEqual(expected.ToString(), schemes.ToString());
-        }
-
-        [Test]
-        public void It_exposes_config_to_implicitly_provide_current_scheme_on_https()
-        {
-            var swagger = GetContent<JObject>("https://tempuri.org/swagger/docs/1.0");
-            var schemes = swagger["schemes"];
-            var expected = JArray.FromObject(new[] { "https" });
-
-            Assert.AreEqual(expected.ToString(), schemes.ToString());
-        }
-
-        [Test]
         public void It_exposes_config_to_explictly_provide_supported_schemes()
         {
             SetUpHandler(c => c.Schemes(new[] { "http", "https" }));
 
             var swagger = GetContent<JObject>("http://tempuri.org/swagger/docs/1.0");
-            var schemes = swagger["schemes"];
-            var expected = JArray.FromObject(new[] { "http", "https" });
-
-            Assert.AreEqual(expected.ToString(), schemes.ToString());
-        }
-
-        [Test]
-        public void It_exposes_config_to_explictly_provide_supported_schemes_on_https()
-        {
-            SetUpHandler(c => c.Schemes(new[] { "http", "https" }));
-
-            var swagger = GetContent<JObject>("https://tempuri.org/swagger/docs/1.0");
             var schemes = swagger["schemes"];
             var expected = JArray.FromObject(new[] { "http", "https" });
 

--- a/Swashbuckle.Tests/Swagger/CoreTests.cs
+++ b/Swashbuckle.Tests/Swagger/CoreTests.cs
@@ -356,11 +356,43 @@ namespace Swashbuckle.Tests.Swagger
         }
 
         [Test]
+        public void It_exposes_config_to_implicitly_provide_current_scheme()
+        {
+            var swagger = GetContent<JObject>("http://tempuri.org/swagger/docs/1.0");
+            var schemes = swagger["schemes"];
+            var expected = JArray.FromObject(new[] { "http" });
+
+            Assert.AreEqual(expected.ToString(), schemes.ToString());
+        }
+
+        [Test]
+        public void It_exposes_config_to_implicitly_provide_current_scheme_on_https()
+        {
+            var swagger = GetContent<JObject>("https://tempuri.org/swagger/docs/1.0");
+            var schemes = swagger["schemes"];
+            var expected = JArray.FromObject(new[] { "https" });
+
+            Assert.AreEqual(expected.ToString(), schemes.ToString());
+        }
+
+        [Test]
         public void It_exposes_config_to_explictly_provide_supported_schemes()
         {
             SetUpHandler(c => c.Schemes(new[] { "http", "https" }));
 
             var swagger = GetContent<JObject>("http://tempuri.org/swagger/docs/1.0");
+            var schemes = swagger["schemes"];
+            var expected = JArray.FromObject(new[] { "http", "https" });
+
+            Assert.AreEqual(expected.ToString(), schemes.ToString());
+        }
+
+        [Test]
+        public void It_exposes_config_to_explictly_provide_supported_schemes_on_https()
+        {
+            SetUpHandler(c => c.Schemes(new[] { "http", "https" }));
+
+            var swagger = GetContent<JObject>("https://tempuri.org/swagger/docs/1.0");
             var schemes = swagger["schemes"];
             var expected = JArray.FromObject(new[] { "http", "https" });
 

--- a/Swashbuckle.Tests/Swagger/CoreTests.cs
+++ b/Swashbuckle.Tests/Swagger/CoreTests.cs
@@ -65,15 +65,20 @@ namespace Swashbuckle.Tests.Swagger
 
             var schemes = swagger["schemes"];
             var expected = JArray.FromObject(new[] { "http" });
-
-            // When there is a virtual directory
-            Configuration = new HttpConfiguration(new HttpRouteCollection("/foobar"));
-            swagger = GetContent<JObject>("http://tempuri.org:1234/swagger/docs/1.0");
-
-            basePath = swagger["basePath"];
-            Assert.AreEqual("/foobar", basePath.ToString());
+            Assert.AreEqual(expected, schemes);
         }
 
+        [Test]
+        public void It_provides_base_path_from_virtual_directory()
+        {
+            // When there is a virtual directory
+            Configuration = new HttpConfiguration(new HttpRouteCollection("/foobar"));
+            var swagger = GetContent<JObject>("http://tempuri.org:1234/swagger/docs/1.0");
+
+            var basePath = swagger["basePath"];
+            Assert.AreEqual("/foobar", basePath.ToString());
+        }
+        
         [Test]
         public void It_provides_a_description_for_each_path_in_the_api()
         {

--- a/Swashbuckle.Tests/Swagger/DefaultRootUrlResolverTests.cs
+++ b/Swashbuckle.Tests/Swagger/DefaultRootUrlResolverTests.cs
@@ -1,0 +1,33 @@
+﻿namespace Swashbuckle.Tests.Swagger
+{
+    using System.Net.Http;
+    using NUnit.Framework;
+    using Swashbuckle.Application;
+
+    [TestFixture]
+    public class DefaultRootUrlResolverTests
+    {
+        [Test]
+        public void It_provides_scheme_host_and_port_from_request_uir()
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, "http://tempuri.org:1234");
+
+            var rootUrl = SwaggerDocsConfig.DefaultRootUrlResolver(request);
+
+            Assert.AreEqual("http://tempuri.org:1234", rootUrl);
+        }
+
+        [Test]
+        public void It_provides_scheme_host_and_port_from_x_forwarded()
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, "http://tempuri.org:1234");
+            request.Headers.Add("X-Forwarded-Proto", "https");
+            request.Headers.Add("X-Forwarded-Host", "acmecorp.org");
+            request.Headers.Add("X-Forwarded-Port", "80");
+
+            var rootUrl = SwaggerDocsConfig.DefaultRootUrlResolver(request);
+
+            Assert.AreEqual("https://acmecorp.org:80", rootUrl);
+        }
+    }
+}

--- a/Swashbuckle.Tests/Swashbuckle.Tests.csproj
+++ b/Swashbuckle.Tests/Swashbuckle.Tests.csproj
@@ -69,6 +69,7 @@
     <Compile Include="SwaggerUi\SwaggerUiTests.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Swagger\DefaultRootUrlResolverTests.cs" />
     <Compile Include="Swagger\FromUriParamsTests.cs" />
     <Compile Include="Swagger\SchemaTests.cs" />
     <Compile Include="Swagger\CoreTests.cs" />


### PR DESCRIPTION
Changed DefaultRootUrlResolver to support X-Forwarded-Proto, X-Forwarded-Host and X-Forwarded-Port headers.
Added unit tests for that.

Added missing assert to existing unit test and split up existing unit test into 2.