### PR TITLE
Document OWIN VirtualPathRoot workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,19 @@ In addition, a stage marker must be used in Startup.cs, AFTER configuring the We
     app.UseWebApi(config);
     app.UseStageMarker(PipelineStage.MapHandler);
 
+### OWIN Hosted in IIS - incorrect VirtualPathRoot handling
+
+When you host WebApi 2 on top of OWIN/SystemWeb, Swashbuckle cannot correctly resolve VirtualPathRoot by default.
+
+You must either explicitly set VirtualPathRoot in your HttpConfiguration at startup, or perform customization like this to fix automatic discovery:
+
+    SwaggerSpecConfig.Customize(c =>
+    {
+        c.ResolveBasePathUsing(req =>
+            req.RequestUri.GetLeftPart(UriPartial.Authority) +
+            req.GetRequestContext().VirtualPathRoot.TrimEnd('/'));
+    }
+
 ### Conflicting Model Id's ###
 
 If you see the following error message in the Swagger UI ...


### PR DESCRIPTION
The call to req.GetConfiguration() in default BasePathResolver implementation requires VirtualPathRoot to be specified in HttpConfiguration at startup.
I first wanted to make a PR that would fix this in code, but you seem to be still targeting WebApi v1, where GetRequestContext() is not supported. So here's at least a workaround recipe.