### PR TITLE
Added support for XML comments.  Fixes #188

### DIFF
--- a/Swashbuckle.Core/Swagger/Filters/ApplyXmlActionComments.cs
+++ b/Swashbuckle.Core/Swagger/Filters/ApplyXmlActionComments.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Web.Http.Controllers;
 using System.Web.Http.Description;
 using System.Xml.XPath;
@@ -16,7 +17,7 @@ namespace Swashbuckle.Swagger.Filters
         private const string RemarksExpression = "remarks";
         private const string ParameterExpression = "param";
         private const string ResponseExpression = "response";
-
+        
         private readonly XPathNavigator _navigator;
 
         public ApplyXmlActionComments(string xmlCommentsPath)
@@ -31,18 +32,18 @@ namespace Swashbuckle.Swagger.Filters
 
             var summaryNode = methodNode.SelectSingleNode(SummaryExpression);
             if (summaryNode != null)
-                operation.summary = summaryNode.Value.Trim();
+                operation.summary = summaryNode.ExtractContent();
 
             var remarksNode = methodNode.SelectSingleNode(RemarksExpression);
             if (remarksNode != null)
-                operation.description = remarksNode.Value.Trim();
+                operation.description = remarksNode.ExtractContent();
 
             ApplyParamComments(operation, methodNode);
 
             ApplyResponseComments(operation, methodNode);
         }
 
-        private static string XPathFor(HttpActionDescriptor actionDescriptor)
+		private static string XPathFor(HttpActionDescriptor actionDescriptor)
         {
             var controllerName = actionDescriptor.ControllerDescriptor.ControllerType.FullName;
             var reflectedActionDescriptor = actionDescriptor as ReflectedHttpActionDescriptor;
@@ -69,7 +70,7 @@ namespace Swashbuckle.Swagger.Filters
                 var paramNode = paramNodes.Current;
                 var parameter = operation.parameters.SingleOrDefault(param => param.name == paramNode.GetAttribute("name", ""));
                 if (parameter != null)
-                    parameter.description = paramNode.Value.Trim();
+                    parameter.description = paramNode.ExtractContent();
             }
         }
 
@@ -85,7 +86,7 @@ namespace Swashbuckle.Swagger.Filters
                 while (responseNodes.MoveNext())
                 {
                     var statusCode = responseNodes.Current.GetAttribute("code", "");
-                    var description = responseNodes.Current.Value.Trim();
+                    var description = responseNodes.Current.ExtractContent();
 
                     var response = new Response
                     {

--- a/Swashbuckle.Core/Swagger/Filters/ApplyXmlTypeComments.cs
+++ b/Swashbuckle.Core/Swagger/Filters/ApplyXmlTypeComments.cs
@@ -27,7 +27,7 @@ namespace Swashbuckle.Swagger.Filters
             {
                 var summaryNode = typeNode.SelectSingleNode(SummaryExpression);
                 if (summaryNode != null)
-                    schema.description = summaryNode.Value.Trim();
+                    schema.description = summaryNode.ExtractContent();
             }
 
             List<Type> typeList = new List<Type>();
@@ -62,7 +62,7 @@ namespace Swashbuckle.Swagger.Filters
             var propSummaryNode = propertyNode.SelectSingleNode(SummaryExpression);
             if (propSummaryNode == null) return;
 
-            schema.description = propSummaryNode.Value.Trim();
+            schema.description = propSummaryNode.ExtractContent();
         }
     }
 }

--- a/Swashbuckle.Core/Swagger/XmlExtensions.cs
+++ b/Swashbuckle.Core/Swagger/XmlExtensions.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Xml;
+using System.Xml.XPath;
+
+namespace Swashbuckle.Swagger
+{
+    /// <summary>
+    /// Extension methods for XML objects
+    /// </summary>
+    public static class XmlExtensions
+    {
+        private static Regex ParamPattern = new Regex(@"<(see|paramref) (name|cref)=""([TPF]{1}:)?(?<display>.+?)"" />");
+        private static Regex ConstPattern = new Regex(@"<c>(?<display>.+?)</c>");
+
+        /// <summary>
+        /// Extracts the display content of the specified <paramref name="node"/>, replacing
+        /// paramref and c tags with a human-readable equivalent.
+        /// </summary>
+        /// <param name="node">The XML node from which to extract content.</param>
+        /// <returns>The extracted content.</returns>
+        public static string ExtractContent(this XPathNavigator node)
+        {
+            if (node == null) return null;
+
+            return ConstPattern.Replace(
+                ParamPattern.Replace(node.InnerXml, GetParamRefName),
+                GetConstRefName).Trim();
+        }
+
+        private static string GetConstRefName(Match match)
+        {
+            if (match.Groups.Count != 2) return null;
+
+            return match.Groups["display"].Value;
+        }
+
+        private static string GetParamRefName(Match match)
+        {
+            if (match.Groups.Count != 5) return null;
+
+            return "{" + match.Groups["display"].Value + "}";
+        }
+    }
+}

--- a/Swashbuckle.Core/Swashbuckle.Core.csproj
+++ b/Swashbuckle.Core/Swashbuckle.Core.csproj
@@ -98,6 +98,7 @@
     <Compile Include="SwaggerUi\EmbeddedAssetProvider.cs" />
     <Compile Include="SwaggerUi\IAssetProvider.cs" />
     <Compile Include="SwaggerUi\StreamExtensions.cs" />
+    <Compile Include="Swagger\XmlExtensions.cs" />
   </ItemGroup>
   <ItemGroup />
   <ItemGroup>

--- a/Swashbuckle.Dummy.Core/Controllers/XmlAnnotatedController.cs
+++ b/Swashbuckle.Dummy.Core/Controllers/XmlAnnotatedController.cs
@@ -7,11 +7,11 @@ namespace Swashbuckle.Dummy.Controllers
     public class XmlAnnotatedController : ApiController
     {
         /// <summary>
-        /// Registers a new Account
+        /// Registers a new Account based on <paramref name="account"/>.
         /// </summary>
-        /// <remarks>Create an account to access restricted resources</remarks>
+        /// <remarks>Create an <see cref="Account"/> to access restricted resources</remarks>
         /// <param name="account">Details for the account to be created</param>
-        /// <response code="201">Account created</response>
+        /// <response code="201"><paramref name="account"/> created</response>
         /// <response code="400">Username already in use</response>
         public int Create(Account account)
         {

--- a/Swashbuckle.Dummy.Core/XmlComments.xml
+++ b/Swashbuckle.Dummy.Core/XmlComments.xml
@@ -6,11 +6,11 @@
     <members>
         <member name="M:Swashbuckle.Dummy.Controllers.XmlAnnotatedController.Create(Swashbuckle.Dummy.Controllers.Account)">
             <summary>
-            Registers a new Account
+            Registers a new Account based on <paramref name="account"/>.
             </summary>
-            <remarks>Create an account to access restricted resources</remarks>
+            <remarks>Create an <see cref="T:Swashbuckle.Dummy.Controllers.Account"/> to access restricted resources</remarks>
             <param name="account">Details for the account to be created</param>
-            <response code="201">Account created</response>
+            <response code="201"><paramref name="account"/> created</response>
             <response code="400">Username already in use</response>
         </member>
         <member name="M:Swashbuckle.Dummy.Controllers.XmlAnnotatedController.UpdateSubAccount(Swashbuckle.Dummy.Controllers.SubAccount)">

--- a/Swashbuckle.Dummy.WebHost/XmlComments.xml
+++ b/Swashbuckle.Dummy.WebHost/XmlComments.xml
@@ -6,11 +6,11 @@
     <members>
         <member name="M:Swashbuckle.Dummy.Controllers.XmlAnnotatedController.Create(Swashbuckle.Dummy.Controllers.Account)">
             <summary>
-            Registers a new Account
+            Registers a new Account based on <paramref name="account"/>.
             </summary>
-            <remarks>Create an account to access restricted resources</remarks>
+            <remarks>Create an <see cref="T:Swashbuckle.Dummy.Controllers.Account"/> to access restricted resources</remarks>
             <param name="account">Details for the account to be created</param>
-            <response code="201">Account created</response>
+            <response code="201"><paramref name="account"/> created</response>
             <response code="400">Username already in use</response>
         </member>
         <member name="M:Swashbuckle.Dummy.Controllers.XmlAnnotatedController.UpdateSubAccount(Swashbuckle.Dummy.Controllers.SubAccount)">

--- a/Swashbuckle.Tests/Swagger/XmlCommentsTests.cs
+++ b/Swashbuckle.Tests/Swagger/XmlCommentsTests.cs
@@ -25,17 +25,17 @@ namespace Swashbuckle.Tests.Swagger
         }
 
         [Test]
-        public void It_documents_operations_from_action_summary_and_remarks_tags()
+        public void It_documents_operations_from_action_summary_and_remarks_tags_including_paramrefs()
         {
             var swagger = GetContent<JObject>("http://tempuri.org/swagger/docs/v1");
 
             var postOp = swagger["paths"]["/xmlannotated"]["post"];
 
             Assert.IsNotNull(postOp["summary"]);
-            Assert.AreEqual("Registers a new Account", postOp["summary"].ToString());
+            Assert.AreEqual("Registers a new Account based on {account}.", postOp["summary"].ToString());
 
             Assert.IsNotNull(postOp["description"]);
-            Assert.AreEqual("Create an account to access restricted resources", postOp["description"].ToString());
+            Assert.AreEqual("Create an {Swashbuckle.Dummy.Controllers.Account} to access restricted resources", postOp["description"].ToString());
         }
 
         [Test]
@@ -64,7 +64,7 @@ namespace Swashbuckle.Tests.Swagger
                     {
                         "201", new
                         {
-                            description = "Account created",
+                            description = "{account} created",
                             schema = new
                             {
                                 format = "int32",


### PR DESCRIPTION
This PR adds support for <paramref>, <see> and <c> blocks in XML comments by wrapping the content of them within curly braces.

This way, the text appears in the documentation instead of being omitted.  The current method (node.InnerText) omits anything that falls inside a child node.