### PR TITLE
Missing mime types

### DIFF
--- a/Swashbuckle.Core/SwaggerUi/EmbeddedAssetProvider.cs
+++ b/Swashbuckle.Core/SwaggerUi/EmbeddedAssetProvider.cs
@@ -62,6 +62,18 @@ namespace Swashbuckle.SwaggerUi
                     return "image/gif";
                 case "png":
                     return "image/png";
+                case "eot":
+                    return "application/vnd.ms-fontobject";
+                case "woff":
+                    return "application/font-woff";
+                case "woff2":
+                    return "application/font-woff2";
+                case "otf":
+                    return "application/font-sfnt"; // formerly "font/opentype"
+                case "ttf":
+                    return "application/font-sfnt"; // formerly "font/truetype"
+                case "svg":
+                    return "image/svg+xml";
                 default:
                     return "text/html";
             }

--- a/Swashbuckle.Tests/SwaggerUi/SwaggerUiTests.cs
+++ b/Swashbuckle.Tests/SwaggerUi/SwaggerUiTests.cs
@@ -162,6 +162,24 @@ namespace Swashbuckle.Tests.SwaggerUi
             Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
+        [TestCase("http://tempuri.org/swagger/ui/images/logo_small-png",                   Result = "image/png")]
+        [TestCase("http://tempuri.org/swagger/ui/css/typography-css",                      Result = "text/css")]
+        [TestCase("http://tempuri.org/swagger/ui/fonts/droid-sans-v6-latin-regular-eot",   Result = "application/vnd.ms-fontobject")]
+        [TestCase("http://tempuri.org/swagger/ui/fonts/droid-sans-v6-latin-regular-woff",  Result = "application/font-woff")]
+        [TestCase("http://tempuri.org/swagger/ui/fonts/droid-sans-v6-latin-regular-woff2", Result = "application/font-woff2")]
+        [TestCase("http://tempuri.org/swagger/ui/fonts/droid-sans-v6-latin-regular-ttf",   Result = "application/font-sfnt")]
+        [TestCase("http://tempuri.org/swagger/ui/fonts/droid-sans-v6-latin-regular-svg",   Result = "image/svg+xml")]
+        public string It_returns_correct_asset_mime_type(string resourceUri)
+        {
+            var response = Get(resourceUri);
+
+            System.Diagnostics.Debug.WriteLine(string.Format("[{0}] {1} => {2}", response.StatusCode, resourceUri, response.Content.Headers.ContentType.MediaType));
+
+            Assert.AreEqual(response.StatusCode, HttpStatusCode.OK);
+
+            return response.Content.Headers.ContentType.MediaType;
+        }
+
         private void SetUpHandler(Action<SwaggerUiConfig> configure = null)
         {
             var swaggerUiConfig = new SwaggerUiConfig(new[] { "swagger/docs/v1" }, SwaggerDocsConfig.DefaultRootUrlResolver);


### PR DESCRIPTION
Added mime-types for the fonts that are contained in the `swagger-ui/src/html/fonts` folder.

They were previously served as "text/html", discovered through a Chrome console warning:
> Resource interpreted as Font but transferred with MIME type text/html: "/docs/fonts/droid-sans-v6-latin-700-woff2".
