### PR TITLE
Changed to type.FullName to properly support nested types in schemas. e....

### DIFF
--- a/Swashbuckle.Core/Swagger/SchemaRegistry.cs
+++ b/Swashbuckle.Core/Swagger/SchemaRegistry.cs
@@ -231,7 +231,7 @@ namespace Swashbuckle.Swagger
         {
             var typeName = type.Name;
             if (_useFullTypeNameInSchemaIds)
-                typeName = type.Namespace + "." + typeName;
+                typeName = type.FullName;
 
             if (type.IsGenericType)
             {


### PR DESCRIPTION
...g., Google.Apis.Storage.v1.Data.ObjectAccessControl+ProjectTeamData will otherwise conflict with Google.Apis.Storage.v1.Data.BucketAccessControl+ProjectTeamData