### PR TITLE
Added AutoGenerate response Models from Attributes

### DIFF
--- a/Swashbuckle.Dummy.Core/SwaggerExtensions/ErrorResponseOperationFilter.cs
+++ b/Swashbuckle.Dummy.Core/SwaggerExtensions/ErrorResponseOperationFilter.cs
@@ -1,0 +1,38 @@
+﻿namespace Swashbuckle.Dummy.SwaggerExtensions
+{
+    using System.Linq;
+    using System.Web.Http.Description;
+    using Swashbuckle.Swagger;
+
+    public class ErrorResponseOperationFilter : IOperationFilter
+    {
+
+        public void Apply(Operation operation, SchemaRegistry schemaRegistry, ApiDescription apiDescription)
+        {
+
+
+            var customAttributesList =
+                apiDescription.ActionDescriptor.GetCustomAttributes<SwaggerResponseModelAttribute>()
+                    .Where(x => x.OperationId == operation.operationId)
+                    .ToList();
+
+            if (customAttributesList.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var customAttributes in customAttributesList)
+            {
+                Schema schema = null;
+                if (customAttributes.ModelType != null)
+                {
+                    schemaRegistry.GetOrRegister(customAttributes.ModelType);
+                    schema = new Schema { @ref = "#/definitions/" + customAttributes.ModelType.Name };
+                }
+                operation.responses.Add(
+                    customAttributes.StatusCode,
+                    new Response { description = customAttributes.Description.Trim(), schema = schema });
+            }
+        }
+    }
+}

--- a/Swashbuckle.Dummy.Core/SwaggerExtensions/SwaggerResponseModelAttribute.cs
+++ b/Swashbuckle.Dummy.Core/SwaggerExtensions/SwaggerResponseModelAttribute.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace Swashbuckle.Dummy.SwaggerExtensions
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true)]
+    public sealed class SwaggerResponseModelAttribute : Attribute
+    {
+        public string OperationId { get; private set; }
+
+        public string StatusCode { get; private set; }
+
+        public string Description { get; private set; }
+
+        public Type ModelType { get; private set; }
+
+        public SwaggerResponseModelAttribute(string operationId, string statusCode, string description, Type type)
+        {
+            this.OperationId = operationId;
+            this.StatusCode = statusCode;
+            this.Description = description;
+            this.ModelType = type;
+        }
+
+        public SwaggerResponseModelAttribute(string operationId, string statusCode, string description) : this (operationId, statusCode, description, null){}
+
+    }
+}

--- a/Swashbuckle.Dummy.Core/Swashbuckle.Dummy.Core.csproj
+++ b/Swashbuckle.Dummy.Core/Swashbuckle.Dummy.Core.csproj
@@ -86,6 +86,8 @@
     <Compile Include="SwaggerExtensions\ApplyDocumentVendorExtensions.cs" />
     <Compile Include="SwaggerExtensions\AssignOAuth2SecurityRequirements.cs" />
     <Compile Include="SwaggerExtensions\DescendingAlphabeticComparer.cs" />
+    <Compile Include="SwaggerExtensions\ErrorResponseOperationFilter.cs" />
+    <Compile Include="SwaggerExtensions\SwaggerResponseModelAttribute.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="App_Start\SwaggerConfig.cs" />


### PR DESCRIPTION
Added ErrorResponseOperationFilter and SwaggerResponseModelAttributeclasses.

Users can now create a SwaggerResponseModelAttribute and decorate end
point and have swashbuckle generate the Models/schemas for Swagger.

example usage:
```
[SwaggerResponseModel("Controller_WithResponseModel", "400", "Description of 400 error", typeof(ModelState))]
[SwaggerResponseModel("Controller_WithoutResponseModel", "500","Description of 500 error")]
```