### PR TITLE
Add null check for memberInfo parameter.

### DIFF
--- a/Swashbuckle.Core/Swagger/XmlComments/ApplyXmlTypeComments.cs
+++ b/Swashbuckle.Core/Swagger/XmlComments/ApplyXmlTypeComments.cs
@@ -45,6 +45,8 @@ namespace Swashbuckle.Swagger.XmlComments
 
         private void ApplyPropertyComments(Schema propertySchema, MemberInfo memberInfo)
         {
+            if (memberInfo == null) return;
+
             var propertyNode = _navigator.SelectSingleNode(
                 String.Format(PropertyExpression, memberInfo.DeclaringType.XmlCommentsId(), memberInfo.Name));
             if (propertyNode == null) return;


### PR DESCRIPTION
I just noticed that if you have an action that returns a model with one or more public fields, an unhandled exception is thrown in **ApplyXmlTypeComments.ApplyPropertyComments()**.

It looks like this happens because **JsonPropertyExtensions.PropertyInfo()** calls **GetProperty()**, which will null for a field and there is no protection inside **ApplyXmlTypeComments.ApplyPropertyComments()** for a null **memberInfo** argument.

I realize it is a bit of an odd case (public fields on classes), but it took a little digging for me to figure out why this was happening when I added to one of our existing APIs so I thought it was worth suggesting.