### PR TITLE
Added null check for memberInfo and test to prove it works 

### DIFF
--- a/Swashbuckle.Core/Swagger/XmlComments/ApplyXmlTypeComments.cs
+++ b/Swashbuckle.Core/Swagger/XmlComments/ApplyXmlTypeComments.cs
@@ -39,7 +39,11 @@ namespace Swashbuckle.Swagger.XmlComments
                 var jsonProperty = context.JsonObjectContract.Properties[entry.Key];
                 if (jsonProperty == null) continue;
 
-                ApplyPropertyComments(entry.Value, jsonProperty.PropertyInfo());
+                var memberInfo = jsonProperty.PropertyInfo();
+                if (memberInfo != null)
+                {
+                    ApplyPropertyComments(entry.Value, memberInfo);
+                }
             }
         }
 

--- a/Swashbuckle.Dummy.Core/Controllers/XmlAnnotatedController.cs
+++ b/Swashbuckle.Dummy.Core/Controllers/XmlAnnotatedController.cs
@@ -56,6 +56,8 @@ namespace Swashbuckle.Dummy.Controllers
     /// </summary>
     public class Account
     {
+        public bool IsPublicField = true;
+
         /// <summary>
         /// The ID for Accounts is 5 digits long.
         /// </summary>

--- a/Swashbuckle.Tests/Swagger/XmlCommentsTests.cs
+++ b/Swashbuckle.Tests/Swagger/XmlCommentsTests.cs
@@ -156,5 +156,12 @@ namespace Swashbuckle.Tests.Swagger
             Assert.IsNotNull(marketingEmailsProperty["description"]);
             Assert.AreEqual("Flag to indicate if marketing emails may be sent", marketingEmailsProperty["description"].ToString());
         }
+
+        [Test]
+        public void It_skips_public_variables()
+        {
+            var swagger = GetContent<JObject>("http://tempuri.org/swagger/docs/v1");
+            Assert.IsNull(swagger["definitions"]["Account"]["IsPublicField"]);
+        }
     }
 }


### PR DESCRIPTION
Added null check before ApplyPropertyComments to avoid null reference exception which previously occured when Swashbuckle attempted to document public variables. Also added test to prove it no longer errors out on public variables.

Probably a duplicate of the latest pull request, forgot to check before I wrote this, but this also verifies the fix with tests.