### PR TITLE
Fetch description from summary tags when using FromUri-attribute

### DIFF
--- a/Swashbuckle.Core/Swagger/FromUriParams/HandleFromUriParams.cs
+++ b/Swashbuckle.Core/Swagger/FromUriParams/HandleFromUriParams.cs
@@ -77,7 +77,8 @@ namespace Swashbuckle.Swagger.FromUriParams
                     {
                         name =  sourceQualifier + entry.Key.ToLowerInvariant(),
                         @in = "query",
-                        required = required
+                        required = required,
+                        description = entry.Value.description
                     };
                     param.PopulateFrom(entry.Value);
                     operationParams.Add(param);

--- a/Swashbuckle.Dummy.Core/Controllers/XmlAnnotatedController.cs
+++ b/Swashbuckle.Dummy.Core/Controllers/XmlAnnotatedController.cs
@@ -41,6 +41,19 @@ namespace Swashbuckle.Dummy.Controllers
         }
 
         /// <summary>
+        /// Filters account based on the given parameters.
+        /// </summary>
+        /// <param name="q">The search query on which to filter accounts</param>
+        /// <param name="page">A complex type describing the paging to be used for the request</param>
+        /// <returns></returns>
+        [HttpGet]
+        [Route("xmlannotated/filter")]
+        public IEnumerable<Account> Filter(string q, [FromUri]Page page)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
         /// Prevents the account from being used
         /// </summary>
         [HttpPut]
@@ -49,6 +62,19 @@ namespace Swashbuckle.Dummy.Controllers
         {
             throw new NotImplementedException();
         }
+    }
+
+    public class Page
+    {
+        /// <summary>
+        /// The maximum number of accounts to return
+        /// </summary>
+        public int Limit { get; set; }
+
+        /// <summary>
+        /// Offset into the result
+        /// </summary>
+        public int Offset { get; set; }
     }
 
     /// <summary>

--- a/Swashbuckle.Dummy.Core/XmlComments.xml
+++ b/Swashbuckle.Dummy.Core/XmlComments.xml
@@ -26,9 +26,27 @@
             <param name="keywords">List of search keywords</param>
             <returns></returns>
         </member>
+        <member name="M:Swashbuckle.Dummy.Controllers.XmlAnnotatedController.Filter(System.String,Swashbuckle.Dummy.Controllers.Page)">
+            <summary>
+            Filters account based on the given parameters.
+            </summary>
+            <param name="q">The search query on which to filter accounts</param>
+            <param name="page">A complex type describing the paging to be used for the request</param>
+            <returns></returns>
+        </member>
         <member name="M:Swashbuckle.Dummy.Controllers.XmlAnnotatedController.PutOnHold(System.Int32)">
             <summary>
             Prevents the account from being used
+            </summary>
+        </member>
+        <member name="P:Swashbuckle.Dummy.Controllers.Page.Limit">
+            <summary>
+            The maximum number of accounts to return
+            </summary>
+        </member>
+        <member name="P:Swashbuckle.Dummy.Controllers.Page.Offset">
+            <summary>
+            Offset into the result
             </summary>
         </member>
         <member name="T:Swashbuckle.Dummy.Controllers.Account">

--- a/Swashbuckle.Dummy.WebHost/XmlComments.xml
+++ b/Swashbuckle.Dummy.WebHost/XmlComments.xml
@@ -26,9 +26,27 @@
             <param name="keywords">List of search keywords</param>
             <returns></returns>
         </member>
+        <member name="M:Swashbuckle.Dummy.Controllers.XmlAnnotatedController.Filter(System.String,Swashbuckle.Dummy.Controllers.Page)">
+            <summary>
+            Filters account based on the given parameters.
+            </summary>
+            <param name="q">The search query on which to filter accounts</param>
+            <param name="page">A complex type describing the paging to be used for the request</param>
+            <returns></returns>
+        </member>
         <member name="M:Swashbuckle.Dummy.Controllers.XmlAnnotatedController.PutOnHold(System.Int32)">
             <summary>
             Prevents the account from being used
+            </summary>
+        </member>
+        <member name="P:Swashbuckle.Dummy.Controllers.Page.Limit">
+            <summary>
+            The maximum number of accounts to return
+            </summary>
+        </member>
+        <member name="P:Swashbuckle.Dummy.Controllers.Page.Offset">
+            <summary>
+            Offset into the result
             </summary>
         </member>
         <member name="T:Swashbuckle.Dummy.Controllers.Account">

--- a/Swashbuckle.Tests/Swagger/XmlCommentsTests.cs
+++ b/Swashbuckle.Tests/Swagger/XmlCommentsTests.cs
@@ -20,6 +20,7 @@ namespace Swashbuckle.Tests.Swagger
         [SetUp]
         public void SetUp()
         {
+            SetUpAttributeRoutesFrom(typeof(XmlAnnotatedController).Assembly);
             SetUpDefaultRouteFor<XmlAnnotatedController>();
             SetUpHandler(c => c.IncludeXmlComments(String.Format(@"{0}\XmlComments.xml", AppDomain.CurrentDomain.BaseDirectory)));
         }
@@ -125,6 +126,26 @@ namespace Swashbuckle.Tests.Swagger
             var usernameProperty = swagger["definitions"]["SubAccount"]["properties"]["AccountID"];
             Assert.IsNotNull(usernameProperty["description"]);
             Assert.AreEqual("The Account ID for SubAccounts should be 7 digits.", usernameProperty["description"].ToString());
+        }
+
+        [Test]
+        public void It_documents_schema_properties_from_summary_tags_of_complex_type_when_query_parameter_is_annotated_with_fromuri_attribute()
+        {
+            var swagger = GetContent<JObject>("http://tempuri.org/swagger/docs/v1");
+
+            var parameters = swagger["paths"]["/xmlannotated/filter"]["get"]["parameters"];
+
+            var qParam = parameters[0];
+            Assert.IsNotNull(qParam["description"]);
+            Assert.AreEqual("The search query on which to filter accounts", qParam["description"].ToString());
+
+            var limitParam = parameters[1];
+            Assert.IsNotNull(limitParam["description"]);
+            Assert.AreEqual("The maximum number of accounts to return", limitParam["description"].ToString());
+
+            var offsetParam = parameters[2];
+            Assert.IsNotNull(offsetParam["description"]);
+            Assert.AreEqual("Offset into the result", offsetParam["description"].ToString());
         }
 
         [Test]


### PR DESCRIPTION
Swashbuckle has the ability to generate parameters from a complex type when marked with the FromUri-attribute, like so:

```c#
public IHttpActionResult Get([FromUri] Page page) { /* ... */ }

public class Page 
{ 
    /// <summary>
    /// The maximum number of items
    /// </summary>
    public int Limit { get; set; }

    /// <summary>
    /// Offset number of items into result
    /// </summary>
    public int Offset { get; set; } 
}
```

When pairing this with XML-comments however the expected behavior, in my opinion, is that the parameters should get their description from the summary tags of the properties of the complex type, which is not currently the case. 

This pull request fixes this issue, and adds a unit test to verify that the summary tags from the XML-comment is carried over to the generated parameters.

An added benefit is that this should also apply to documentation generated via the ```SwaggerDocsConfig.MapType```-method as well, although I have not written a test to verify that this is the case.