### PR TITLE
Handle null jsonProperty.UnderlyingName values

### DIFF
--- a/Swashbuckle.Core/Swagger/JsonPropertyExtensions.cs
+++ b/Swashbuckle.Core/Swagger/JsonPropertyExtensions.cs
@@ -25,6 +25,7 @@ namespace Swashbuckle.Swagger
 
         public static PropertyInfo PropertyInfo(this JsonProperty jsonProperty)
         {
+            if(jsonProperty.UnderlyingName == null) return null;
             return jsonProperty.DeclaringType.GetProperty(jsonProperty.UnderlyingName, jsonProperty.PropertyType);
         }
     }


### PR DESCRIPTION
In some scenarios the jsonProperty.UnderlyingName is null. For instance if we have custom contract resolvers like in https://github.com/kekekeks/hal-json-net/blob/5292c6f85c819e5fbcd26c13afe79aff3becfc04/HalJsonNet/Serialization/JsonNetHalJsonContactResolver.cs#L60 that inject custom values in the response.

As a side effect of this change the response model will default to object.

Note that without this, the API swagger generation process throw an exception.