### PR TITLE
Fixed a bug which occurs with bad XML documentation

### DIFF
--- a/Swashbuckle.Core/Swagger/XmlComments/ApplyXmlActionComments.cs
+++ b/Swashbuckle.Core/Swagger/XmlComments/ApplyXmlActionComments.cs
@@ -64,6 +64,8 @@ namespace Swashbuckle.Swagger.XmlComments
 
         private static void ApplyParamComments(Operation operation, XPathNavigator methodNode)
         {
+            if (operation.parameters == null) return;
+
             var paramNodes = methodNode.Select(ParameterExpression);
             while (paramNodes.MoveNext())
             {

--- a/Swashbuckle.Dummy.Core/Controllers/XmlAnnotatedController.cs
+++ b/Swashbuckle.Dummy.Core/Controllers/XmlAnnotatedController.cs
@@ -54,6 +54,19 @@ namespace Swashbuckle.Dummy.Controllers
             throw new NotImplementedException();
         }
 
+#pragma warning disable 1572 // intensionally testing that this warning doesn't cause swashbuckler to crash
+        /// <summary>
+        /// Returns all existing accounts
+        /// </summary>
+        /// <param name="q">A non-existant parameter on a method with no parameters</param>
+        [HttpGet]
+        [Route("all")]
+        public IEnumerable<Account> GetAll()
+        {
+            throw new NotImplementedException();
+        }
+#pragma warning restore 1572
+
         /// <summary>
         /// Prevents the account from being used
         /// </summary>

--- a/Swashbuckle.Dummy.Core/XmlComments.xml
+++ b/Swashbuckle.Dummy.Core/XmlComments.xml
@@ -34,6 +34,12 @@
             <param name="page">A complex type describing the paging to be used for the request</param>
             <returns></returns>
         </member>
+        <member name="M:Swashbuckle.Dummy.Controllers.XmlAnnotatedController.GetAll">
+            <summary>
+            Returns all existing accounts
+            </summary>
+            <param name="q">A non-existant parameter on a method with no parameters</param>
+        </member>
         <member name="M:Swashbuckle.Dummy.Controllers.XmlAnnotatedController.PutOnHold(System.Int32)">
             <summary>
             Prevents the account from being used

--- a/Swashbuckle.Dummy.WebHost/XmlComments.xml
+++ b/Swashbuckle.Dummy.WebHost/XmlComments.xml
@@ -34,6 +34,12 @@
             <param name="page">A complex type describing the paging to be used for the request</param>
             <returns></returns>
         </member>
+        <member name="M:Swashbuckle.Dummy.Controllers.XmlAnnotatedController.GetAll">
+            <summary>
+            Returns all existing accounts
+            </summary>
+            <param name="q">A non-existant parameter on a method with no parameters</param>
+        </member>
         <member name="M:Swashbuckle.Dummy.Controllers.XmlAnnotatedController.PutOnHold(System.Int32)">
             <summary>
             Prevents the account from being used


### PR DESCRIPTION
XML documentation can get out of sync with methods.

When an operation/method contains no/null parameters, but there are "param" documentation nodes, Swashbuckler would crash with a ArgumentNullException trying to call SingleOrDefault to find the parameter to update.

This fixes the problem by simply bailing out of the ApplyParamComments if the operation.parameters is null, as there can be no actual parameters to document.