### PR TITLE
Add an overload to IncludeXmlComments that takes a document

### DIFF
--- a/Swashbuckle.Core/Application/SwaggerDocsConfig.cs
+++ b/Swashbuckle.Core/Application/SwaggerDocsConfig.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Web.Http;
 using System.Web.Http.Description;
+using System.Xml;
 using Newtonsoft.Json.Converters;
 using Swashbuckle.Swagger;
 using Swashbuckle.Swagger.FromUriParams;
@@ -190,8 +191,15 @@ namespace Swashbuckle.Application
 
         public void IncludeXmlComments(string filePath)
         {
-            OperationFilter(() => new ApplyXmlActionComments(filePath));
-            ModelFilter(() => new ApplyXmlTypeComments(filePath));
+            XmlDocument document = new XmlDocument();
+            document.Load(filePath);
+            IncludeXmlComments(document);
+        }
+
+        public void IncludeXmlComments(XmlDocument document)
+        {
+            OperationFilter(() => new ApplyXmlActionComments(document));
+            ModelFilter(() => new ApplyXmlTypeComments(document));
         }
 
         public void ResolveConflictingActions(Func<IEnumerable<ApiDescription>, ApiDescription> conflictingActionsResolver)

--- a/Swashbuckle.Core/Swagger/XmlComments/ApplyXmlActionComments.cs
+++ b/Swashbuckle.Core/Swagger/XmlComments/ApplyXmlActionComments.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Web.Http.Controllers;
 using System.Web.Http.Description;
+using System.Xml;
 using System.Xml.XPath;
 using Swashbuckle.Swagger;
 
@@ -21,8 +22,13 @@ namespace Swashbuckle.Swagger.XmlComments
         private readonly XPathNavigator _navigator;
 
         public ApplyXmlActionComments(string xmlCommentsPath)
+            : this(new XPathDocument(xmlCommentsPath))
         {
-            _navigator = new XPathDocument(xmlCommentsPath).CreateNavigator();
+        }
+
+        public ApplyXmlActionComments(XmlDocument document)
+        {
+            _navigator = document.CreateNavigator();
         }
 
         public void Apply(Operation operation, SchemaRegistry schemaRegistry, ApiDescription apiDescription)

--- a/Swashbuckle.Core/Swagger/XmlComments/ApplyXmlTypeComments.cs
+++ b/Swashbuckle.Core/Swagger/XmlComments/ApplyXmlTypeComments.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Text;
 using System.Reflection;
+using System.Xml;
 using Newtonsoft.Json.Serialization;
 using Swashbuckle.Swagger;
 
@@ -18,8 +19,13 @@ namespace Swashbuckle.Swagger.XmlComments
         private readonly XPathNavigator _navigator;
 
         public ApplyXmlTypeComments(string xmlCommentsPath)
+            : this(new XPathDocument(xmlCommentsPath))
         {
-            _navigator = new XPathDocument(xmlCommentsPath).CreateNavigator();
+        }
+
+        public ApplyXmlTypeComments(XmlDocument document)
+        {
+            _navigator = document.CreateNavigator();
         }
 
         public void Apply(Schema model, ModelFilterContext context)


### PR DESCRIPTION
I think we have a bit of an abnormal use case, but I would hope that this is seen as a minor/unobtrusive change...

Our current build process actually includes the DocXml as an embedded resource in our assembly.  This way, implementation details of our APIs that really aren't "public" (i.e., we don't want people to build stuff against our .NET assemblies) are tucked away.  This change provides an overload so that we can provide an XmlDocument to Swashbuckle that's been loaded from the embedded resource stream.
