### PR TITLE
Maximum and Minimum Length in Schema

### DIFF
--- a/Swashbuckle.Core/Swagger/SchemaExtensions.cs
+++ b/Swashbuckle.Core/Swagger/SchemaExtensions.cs
@@ -30,6 +30,13 @@ namespace Swashbuckle.Swagger
                     if (Int32.TryParse(range.Minimum.ToString(), out minimum))
                         schema.minimum = minimum;
                 }
+
+                var length = attribute as StringLengthAttribute;
+                if (length != null)
+                {
+                    schema.maxLength = length.MaximumLength;
+                    schema.minLength = length.MinimumLength;
+                }
             }
 
             if (!jsonProperty.Writable)

--- a/Swashbuckle.Dummy.Core/Controllers/AnnotatedTypesController.cs
+++ b/Swashbuckle.Dummy.Core/Controllers/AnnotatedTypesController.cs
@@ -32,6 +32,7 @@ namespace Swashbuckle.Dummy.Controllers
         [Required, Range(14, 99)]
         public int ExpYear { get; set; }
 
+        [StringLength(500, MinimumLength = 10)]
         public string Note { get; set; }
     }
 }

--- a/Swashbuckle.Tests/Swagger/SchemaTests.cs
+++ b/Swashbuckle.Tests/Swagger/SchemaTests.cs
@@ -112,6 +112,8 @@ namespace Swashbuckle.Tests.Swagger
                             },
                             Note = new
                             {
+                                maxLength = 500,
+                                minLength = 10,
                                 type = "string"
                             }
                         }


### PR DESCRIPTION
The current Swagger specification allows to set a maximum and a minimum length in the schema definition. The fields themselves are already in the object specification itself, but aren't used currently.
The allowed lengths can be set in .NET by the "StringLengthAttribute" on the fields.

I added the logic to test for them, and set the lengths if available. It is also added in the unit tests, which worked fine.