### PR TITLE
Changed Response.headers from IList<Header> to IDictionary<string, Header>

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 [Oo]bj/
 [Bb]in/
 App_Data
-Packages
+[Pp]ackages
 Logs
 PrecompiledWeb/
 

--- a/Swashbuckle.Core/Swagger/SwaggerDocument.cs
+++ b/Swashbuckle.Core/Swagger/SwaggerDocument.cs
@@ -267,7 +267,7 @@ namespace Swashbuckle.Swagger
 
         public Schema schema;
 
-        public IList<Header> headers;
+        public IDictionary<string, Header> headers;
 
         public object examples;
     }


### PR DESCRIPTION
Changed Response.headers from IList&lt;Header> to IDictionary&lt;string, Header>
- IList generates array, and it is not possible to specify header name
- Swagger 2.0 spec says it is supposed to be object in form { 'header-name': Header, 'another-header': Header }
