### PR TITLE
Support for OpenID for implicit flow by ading the required nonce

### DIFF
--- a/Swashbuckle.Core/Application/SecuritySchemeBuilder.cs
+++ b/Swashbuckle.Core/Application/SecuritySchemeBuilder.cs
@@ -73,6 +73,7 @@ namespace Swashbuckle.Application
         private string _authorizationUrl;
         private string _tokenUrl;
         private IDictionary<string, string> _scopes = new Dictionary<string, string>();
+        private string _responseType;
 
         public OAuth2SchemeBuilder Description(string description)
         {
@@ -103,6 +104,12 @@ namespace Swashbuckle.Application
             configure(_scopes);
             return this;
         }
+        
+        public OAuth2SchemeBuilder ResponseType(string responseType)
+        {
+            _responseType = responseType;
+            return this;
+        }
 
         internal override SecurityScheme Build()
         {
@@ -116,6 +123,7 @@ namespace Swashbuckle.Application
                 tokenUrl = _tokenUrl,
                 scopes = _scopes,
                 description = _description,
+                responseType = _responseType
             };
         }
     }

--- a/Swashbuckle.Core/Swagger/SwaggerDocument.cs
+++ b/Swashbuckle.Core/Swagger/SwaggerDocument.cs
@@ -309,5 +309,7 @@ namespace Swashbuckle.Swagger
         public IDictionary<string, string> scopes;
 
         public Dictionary<string, object> vendorExtensions = new Dictionary<string, object>();
+
+        public string responseType;
     }
 }

--- a/Swashbuckle.Core/SwaggerUi/CustomAssets/swagger-oauth.js
+++ b/Swashbuckle.Core/SwaggerUi/CustomAssets/swagger-oauth.js
@@ -100,6 +100,7 @@ function handleLogin() {
     var defaultRedirectUrl = host.protocol + '//' + host.host + pathname + '/o2c-html';
     var redirectUrl = window.oAuthRedirectUrl || defaultRedirectUrl;
     var url = null;
+    var validResponseTypes = ['code', 'token', 'id_token', 'id_token token', 'code id_token', 'code token', 'code id_token token'];
 
     for (var key in authSchemes) {
       if (authSchemes.hasOwnProperty(key)) {
@@ -107,7 +108,11 @@ function handleLogin() {
 
         if(authSchemes[key].type === 'oauth2' && flow && (flow === 'implicit' || flow === 'accessCode')) {
           var dets = authSchemes[key];
-          url = dets.authorizationUrl + '?response_type=' + (flow === 'implicit' ? 'token' : 'code');
+          var responseType = (flow === 'implicit' ? 'token' : 'code');
+          if(validResponseTypes.indexOf(authSchemes[key].responseType) >= 0) {
+            responseType = encodeURIComponent(authSchemes[key].responseType);
+          }
+          url = dets.authorizationUrl + '?response_type=' + responseType;
           window.swaggerUi.tokenName = dets.tokenName || 'access_token';
           window.swaggerUi.tokenUrl = (flow === 'accessCode' ? dets.tokenUrl : null);
         }
@@ -154,6 +159,11 @@ function handleLogin() {
     url += '&scope=' + encodeURIComponent(scopes.join(' '));
     url += '&state=' + encodeURIComponent(state);
 
+    if (flow === 'implicit' && authSchemes[key].responseType.indexOf("id_token") >= 0) {
+      // implicit auth with id_token in the response type needs a nonce
+      var nonce = Math.random();
+      url += '&nonce=' + encodeURIComponent(nonce);
+    }
     window.open(url);
   });
 

--- a/Swashbuckle.Tests/Swagger/SecurityTests.cs
+++ b/Swashbuckle.Tests/Swagger/SecurityTests.cs
@@ -111,5 +111,49 @@ namespace Swashbuckle.Tests.SwaggerFilters
 
             Assert.AreEqual(expected.ToString(), securityDefinitions.ToString());
         }
+
+        [Test]
+        public void It_exposes_config_to_define_custom_responsetypes_for_the_api()
+        {
+            SetUpHandler(c =>
+            {
+                c.OAuth2("oauth2")
+                    .Description("OAuth2 Implicit Id Token Grant")
+                    .Flow("implicit")
+                    .AuthorizationUrl("https://tempuri.org/auth")
+                    .TokenUrl("https://tempuri.org/token")
+                    .Scopes(s =>
+                    {
+                        s.Add("read", "Read access to protected resources");
+                        s.Add("write", "Write access to protected resources");
+                        s.Add("openid", "OpenId access");
+                    })
+                    .ResponseType("id_token token");
+            });
+
+            var swagger = GetContent<JObject>("http://tempuri.org/swagger/docs/v1");
+            var securityDefinitions = swagger["securityDefinitions"];
+            var expected = JObject.FromObject(new
+            {
+                oauth2 = new
+                {
+                    type = "oauth2",
+                    description = "OAuth2 Implicit Id Token Grant",
+                    flow = "implicit",
+                    authorizationUrl = "https://tempuri.org/auth",
+                    tokenUrl = "https://tempuri.org/token",
+                    scopes = new
+                    {
+                        read = "Read access to protected resources",
+                        write = "Write access to protected resources",
+                        openid = "OpenId access"
+                    },
+                    responseType = "id_token token"
+                }
+            });
+
+            Assert.AreEqual(expected.ToString(), securityDefinitions.ToString());
+        }
+
     }
 }


### PR DESCRIPTION
We are using the IdentityServer3 as our identity provider is our project.  We also use Swagger / Swashbuckle to access an API.  The IdentityServer3 allows quite a bit of customization around how you can authorize, what flows you can use, etc.  This is to address issue #390 

We are using a response type of `id_token token` and the implicit flow.  When using the implicit flow and requesting an identity token a nonce is required.  This change allows the user to set their own response type and, when using id_token and the implicit flow, get a valid authorize request that includes a nonce.
