### PR TITLE
SwaggerSchemaFilterAttribute

### DIFF
--- a/Swashbuckle.Core/Swagger/Annotations/ApplySwaggerSchemaFilterAttributes.cs
+++ b/Swashbuckle.Core/Swagger/Annotations/ApplySwaggerSchemaFilterAttributes.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Web.Http.Description;
 
@@ -8,13 +9,26 @@ namespace Swashbuckle.Swagger.Annotations
     {
         public void Apply(Schema schema, SchemaRegistry schemaRegistry, Type type)
         {
-            var attributes = type.GetCustomAttributes(false).OfType<SwaggerSchemaFilterAttribute>();
+			// create list of base types
+			Stack<Type> types = new Stack<Type>();
+			types.Push(type);
 
-            foreach (var attribute in attributes)
-            {
-                var filter = (ISchemaFilter)Activator.CreateInstance(attribute.FilterType);
-                filter.Apply(schema, schemaRegistry, type);
-            }
+			Type t;
+			while ((t = types.Peek().BaseType) != null)
+			{
+				types.Push(t);
+			}
+
+			// walk attributes in order base-type -> child-type
+			// GetCustomAttributes(inherit: true) walks types in opposite direction and simple reverse would not suffice if multiple attributes are applied
+			while (types.Count > 0)
+			{
+				foreach (SwaggerSchemaFilterAttribute attribute in types.Pop().GetCustomAttributes(typeof(SwaggerSchemaFilterAttribute), false))
+				{
+					var filter = (ISchemaFilter)Activator.CreateInstance(attribute.FilterType);
+					filter.Apply(schema, schemaRegistry, type);
+				}
+			}
         }
     }
 }

--- a/Swashbuckle.Core/Swagger/Annotations/SwaggerSchemaFilterAttribute.cs
+++ b/Swashbuckle.Core/Swagger/Annotations/SwaggerSchemaFilterAttribute.cs
@@ -2,7 +2,7 @@
 
 namespace Swashbuckle.Swagger.Annotations
 {
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
     public class SwaggerSchemaFilterAttribute : Attribute
     {
         public SwaggerSchemaFilterAttribute(Type filterType)


### PR DESCRIPTION
**Changes in this pull request**
- allowing to use multiple attributes
- when applying SwaggerSchemaFilterAttribute, also applying them from base class

**Inheriting attributes**
Motivation:
When having class B derived from class A, while class A applies filter and modifies its fields in a way, if we also want to modify (the new) fields in class B, we needed to do something like this (pseudo code):

```
class BFilter: ISchemaFilter {
  void Apply(schema) {
    ISchemaFilter baseFilter = new AFilter();
    baseFilter.Apply(schema);
    //now apply logic for BFilter
  }
}
```

Which is:
- tedious
- error prone
- needs to know what class is the filter of my base class

With the fix it is possible to have code:

```
[SwaggerSchemaFilter(typeof(AFilter))]
class A {}

[SwaggerSchemaFilter(typeof(BFilter))]
class B : A {}
```
- this will first apply AFilter, then BFilter
- this will work seamlessly without any additional code in filters

**Multiple filters**
Motivation:

```
[SwaggerSchemaFilter(typeof(A))]
[SwaggerSchemaFilter(typeof(CommonFilter))]
class A : ISchemaFilter {}
```
- with multiple attributes it is possible to have
  - filters specific to the class
  - generic filters applied to set of classes
- before the patch, we needed to create wrapping filter that applies both filters manually, which is
  - tedious
  - needs to create wrapping class filters for each scenario
  - hard to maintain

Signed-off-by: Marek Hübsch mhubsch@intermap.com
