### PR TITLE
Remove port if is default

### DIFF
--- a/Swashbuckle.Core/Swagger/SwaggerGenerator.cs
+++ b/Swashbuckle.Core/Swagger/SwaggerGenerator.cs
@@ -51,11 +51,12 @@ namespace Swashbuckle.Swagger
                 .ToDictionary(group => "/" + group.Key, group => CreatePathItem(group, schemaRegistry));
 
             var rootUri = new Uri(rootUrl);
+            var port = (!rootUri.IsDefaultPort) ? ":" + rootUri.Port : string.Empty;
 
             var swaggerDoc = new SwaggerDocument
             {
                 info = info,
-                host = rootUri.Host + ":" + rootUri.Port,
+                host = rootUri.Host + port,
                 basePath = (rootUri.AbsolutePath != "/") ? rootUri.AbsolutePath : null,
                 schemes = (_options.Schemes != null) ? _options.Schemes.ToList() : new[] { rootUri.Scheme }.ToList(),
                 paths = paths,


### PR DESCRIPTION
Swashbuckle is putting the port in the host address. But if it's a default port, it's not necessary. In some cases, it's not desired inclusive.