### PR TITLE
Adding option to disable syntax highlighting

### DIFF
--- a/Swashbuckle.Core/Application/SwaggerUiConfig.cs
+++ b/Swashbuckle.Core/Application/SwaggerUiConfig.cs
@@ -30,7 +30,9 @@ namespace Swashbuckle.Application
                 { "%(OAuth2ClientId)", "" },
                 { "%(OAuth2ClientSecret)", "" },
                 { "%(OAuth2Realm)", "" },
-                { "%(OAuth2AppName)", "" }
+                { "%(OAuth2AppName)", "" },
+                { "%(disableHighlighting)", "false" }
+
             };
             _rootUrlResolver = rootUrlResolver;
 
@@ -54,7 +56,7 @@ namespace Swashbuckle.Application
 
             CustomAsset(path, resourceAssembly, resourceName);
         }
-        
+
         public void BooleanValues(IEnumerable<string> values)
         {
             _templateParams["%(BooleanValues)"] = String.Join("|", values);
@@ -68,6 +70,11 @@ namespace Swashbuckle.Application
         public void DisableValidator()
         {
             _templateParams["%(ValidatorUrl)"] = "null";
+        }
+
+        public void DisableHighlighting()
+        {
+            _templateParams["%(disableHighlighting)"] = "true";
         }
 
         public void InjectJavaScript(Assembly resourceAssembly, string resourceName)

--- a/Swashbuckle.Core/SwaggerUi/CustomAssets/index.html
+++ b/Swashbuckle.Core/SwaggerUi/CustomAssets/index.html
@@ -22,7 +22,7 @@
   <script src='lib/highlight-7-3-pack-js' type='text/javascript'></script>
   <script src='lib/marked-js' type='text/javascript'></script>
   <script src='lib/swagger-oauth-js' type='text/javascript'></script>
-  
+
   <!-- Some basic translations -->
   <!-- <script src='lang/translator.js' type='text/javascript'></script> -->
   <!-- <script src='lang/ru.js' type='text/javascript'></script> -->
@@ -57,9 +57,10 @@
         oAuth2ClientId: '%(OAuth2ClientId)',
         oAuth2ClientSecret: '%(OAuth2ClientSecret)',
         oAuth2Realm: '%(OAuth2Realm)',
-        oAuth2AppName: '%(OAuth2AppName)'
+        oAuth2AppName: '%(OAuth2AppName)',
+        disableHighlighting: ('%(disableHighlighting)' == 'true')
       };
-	  
+
 	  // Pre load translate...
       if(window.SwaggerTranslator) {
         window.SwaggerTranslator.translate();
@@ -76,17 +77,20 @@
               clientSecret: swashbuckleConfig.oAuth2ClientSecret,
               realm: swashbuckleConfig.oAuth2Realm,
               appName: swashbuckleConfig.oAuth2AppName,
-			        scopeSeperator: ","
+              scopeSeperator: ",",
+              disableHighlighting: swashbuckleConfig.disableHighlighting
             });
           }
-		  
+
           if(window.SwaggerTranslator) {
             window.SwaggerTranslator.translate();
           }
 
-          $('pre code').each(function(i, e) {
-            hljs.highlightBlock(e)
-          });
+          if (!swashbuckleConfig.disableHighlighting) {
+            $('pre code').each(function(i, e) {
+              hljs.highlightBlock(e);
+            });
+          }
 
           addApiKeyAuthorization();
 

--- a/Swashbuckle.Core/SwaggerUi/CustomAssets/swagger-oauth.js
+++ b/Swashbuckle.Core/SwaggerUi/CustomAssets/swagger-oauth.js
@@ -197,7 +197,10 @@ function initOAuth(opts) {
     return;
   }
 
-  $('pre code').each(function(i, e) {hljs.highlightBlock(e)});
+  if (!o.disableHighlighting) {
+      $('pre code').each(function (i, e) { hljs.highlightBlock(e) });
+  }
+
   $('.api-ic').unbind();
   $('.api-ic').click(function(s) {
     if($(s.target).hasClass('ic-off'))

--- a/Swashbuckle.WebHost/Nuget/Content/App_Start/SwaggerConfig.cs.pp
+++ b/Swashbuckle.WebHost/Nuget/Content/App_Start/SwaggerConfig.cs.pp
@@ -13,7 +13,7 @@ namespace $rootnamespace$
         {
             var thisAssembly = typeof(SwaggerConfig).Assembly;
 
-            GlobalConfiguration.Configuration 
+            GlobalConfiguration.Configuration
                 .EnableSwagger(c =>
                     {
                         // By default, the service root url is inferred from the request used to access the docs.
@@ -117,7 +117,7 @@ namespace $rootnamespace$
                         //c.SchemaFilter<ApplySchemaVendorExtensions>();
 
                         // Set this flag to omit schema property descriptions for any type properties decorated with the
-                        // Obsolete attribute 
+                        // Obsolete attribute
                         //c.IgnoreObsoleteProperties();
 
                         // In a Swagger 2.0 document, complex types are typically declared globally and referenced by unique
@@ -132,7 +132,7 @@ namespace $rootnamespace$
                         // You can change the serializer behavior by configuring the StringToEnumConverter globally or for a given
                         // enum type. Swashbuckle will honor this change out-of-the-box. However, if you use a different
                         // approach to serialize enums as strings, you can also force Swashbuckle to describe them as strings.
-                        // 
+                        //
                         //c.DescribeAllEnumsAsStrings();
 
                         // Similar to Schema filters, Swashbuckle also supports Operation and Document filters:
@@ -158,7 +158,7 @@ namespace $rootnamespace$
                         // In contrast to WebApi, Swagger 2.0 does not include the query string component when mapping a URL
                         // to an action. As a result, Swashbuckle will raise an exception if it encounters multiple actions
                         // with the same path (sans query string) and HTTP method. You can workaround this by providing a
-                        // custom strategy to pick a winner or merge the descriptions for the purposes of the Swagger docs 
+                        // custom strategy to pick a winner or merge the descriptions for the purposes of the Swagger docs
                         //
                         //c.ResolveConflictingActions(apiDescriptions => apiDescriptions.First());
 
@@ -186,6 +186,10 @@ namespace $rootnamespace$
                         // for example 0 and 1.
                         //
                         //c.BooleanValues(new[] { "0", "1" });
+
+						// The swagger-ui applies syntax highlighting by default. This can introduce performance problems
+						// loading large documents. You can use this option to disable the highlighting
+						// c.DisableHighlighting();
 
                         // By default, swagger-ui will validate specs against swagger.io's online validator and display the result
                         // in a badge at the bottom of the page. Use these options to set a different validator URL or to disable the


### PR DESCRIPTION
On large documentation files, especially those with large return objects, the syntax highlighting is a bear. We were looking at 10s just to render the doc. Disabling this reduces the load time significantly.

Ultimately this feels like a swagger-ui problem, not a swashbuckle problem. I don't like the idea of having to maintain this fix, but the way they have their code structured right now the highlighting is done via a combination of index.html and in the oauth javascript file. Seems like they hacked it in at the last second. I'm not sure there would be a response from them beyond customizing the index.html file which brings us back to needing this to live close to whoever is serving the file up. Which in this case is swashbuckle.

Just throwing this out there. Worst case I can serve up a customized index.html and swagger-oauth.js myself but I thought this functionality might benefit others.
