### PR TITLE
SwaggerDocsConfig.DescribeAllEnumsAsStrings now applied across the entire SwaggerDocument consistently

### DIFF
--- a/Swashbuckle.Core/Swagger/ISwaggerProvider.cs
+++ b/Swashbuckle.Core/Swagger/ISwaggerProvider.cs
@@ -5,6 +5,8 @@ namespace Swashbuckle.Swagger
     public interface ISwaggerProvider
     {
         SwaggerDocument GetSwagger(string rootUrl, string apiVersion);
+
+	      SwaggerGeneratorOptions GetOptions();
     }
 
     public class UnknownApiVersion : Exception

--- a/Swashbuckle.Core/Swagger/SwaggerGenerator.cs
+++ b/Swashbuckle.Core/Swagger/SwaggerGenerator.cs
@@ -27,6 +27,11 @@ namespace Swashbuckle.Swagger
             _options = options ?? new SwaggerGeneratorOptions();
         }
 
+			  public SwaggerGeneratorOptions GetOptions()
+	      {
+		        return _options;
+	      }
+
         public SwaggerDocument GetSwagger(string rootUrl, string apiVersion)
         {
             var schemaRegistry = new SchemaRegistry(


### PR DESCRIPTION
Hey,
I was trying to create examples for Schema objects, and one of these objects contained an enum. Even though the swashbuckle middleware was configured with DescribeAllEnumsAsStrings, the example for that schema object had it's enum value serialized as int, instead of string.

DescribeAllEnumsAsStrings is only taken into account in SchemaRegistry.CreateEnumSchema, not when the actual SwaggerDocument instance is passed as response to Web API for JSON serialization, meaning that fields like example(s) will get serialized without considering this option.

This is my attempt to modify this behavior to work as expected, in the least intrusive way...