### PR TITLE
Fixed a couple of spelling errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Swashbuckle 5.0
 
 Seamlessly adds a [Swagger](http://swagger.io/) to WebApi projects! Combines ApiExplorer and Swagger/swagger-ui to provide a rich discovery, documentation and playground experience to your API consumers.
 
-In addition to its Swagger generator, Swashbuckle also contains an embedded version of [swagger-ui](https://github.com/swagger-api/swagger-ui) which it will automatically serve up once Swashbuckle is installed. This means you can compliment your API with a slick discovery UI to assist consumers with their integration efforts. Best of all, it requires minimal coding and maintenance, allowing you to focus on building an awesome API!
+In addition to its Swagger generator, Swashbuckle also contains an embedded version of [swagger-ui](https://github.com/swagger-api/swagger-ui) which it will automatically serve up once Swashbuckle is installed. This means you can complement your API with a slick discovery UI to assist consumers with their integration efforts. Best of all, it requires minimal coding and maintenance, allowing you to focus on building an awesome API!
 
 And that's not all ...
 
@@ -21,11 +21,11 @@ Once you have a Web API that can describe itself in Swagger, you've opened the t
 
 **\*Swashbuckle 5.0**
 
-Swashbuckle 5.0 makes the transition to Swagger 2.0. The 2.0 schema is significantly different to its predecessor - 1.2 and, as a result, the Swashbuckle config interface has undergone yet another overhaul. Checkout the [transition guide](#transitioning-to-swashbuckle-50) if you're upgrading from a prior version.
+Swashbuckle 5.0 makes the transition to Swagger 2.0. The 2.0 schema is significantly different to its predecessor (1.2) and, as a result, the Swashbuckle config interface has undergone yet another overhaul. Checkout the [transition guide](#transitioning-to-swashbuckle-50) if you're upgrading from a prior version.
 
 ## Getting Started ##
 
-There are currently two Nuget packages - the Core library (Swashbuckle.Core) and a convenience package (Swashbuckle) that provides automatic bootstrapping. The latter is only applicable to regular IIS hosted WepApi's. For all other hosting environments, you should only install the Core library and then follow the instructions below to manually enable the Swagger routes.
+There are currently two Nuget packages - the Core library (Swashbuckle.Core) and a convenience package (Swashbuckle)  - that provides automatic bootstrapping. The latter is only applicable to regular IIS hosted Web APIs. For all other hosting environments, you should only install the Core library and then follow the instructions below to manually enable the Swagger routes.
 
 Once installed and enabled, you should be able to browse the following Swagger docs and UI endpoints respectively:
 
@@ -47,7 +47,7 @@ If your service is self-hosted, just install the Core library:
 
     Install-Package Swashbuckle.Core
 
-And then manually enable the Swagger docs and optionally, the swagger-ui by invoking the following extension methods (in namespace Swashbuckle.Application) on an instance of HttpConfiguration (e.g. in Program.cs)
+Then manually enable the Swagger docs and, optionally, the swagger-ui by invoking the following extension methods (in namespace Swashbuckle.Application) on an instance of HttpConfiguration (e.g. in Program.cs)
 
     httpConfiguration
         .EnableSwagger(c => c.SingleApiVersion("v1", "A title for your API"))
@@ -67,7 +67,7 @@ Then manually enable the Swagger docs and swagger-ui by invoking the extension m
 
 ## Troubleshooting ##
 
-Troubleshooting??? I thought this was all supposed to be "seamless"? OK you've called me out! Things shouldn't go wrong, but if they do, take a look at the [FAQ's](#troubleshooting-and-faqs) for inspiration.
+Troubleshooting??? I thought this was all supposed to be "seamless"? OK you've called me out! Things shouldn't go wrong, but if they do, take a look at the [FAQs](#troubleshooting-and-faqs) for inspiration.
 
 ## Customizing the Generated Swagger Docs ##
 
@@ -91,7 +91,7 @@ In this case the URL to swagger-ui will be `sandbox/ui/index`.
 
 ### Additional Service Metadata ###
 
-In addition to operation descriptions, Swagger 2.0 includes several properties to describe the service itself. These can all be provided through the config. interface:
+In addition to operation descriptions, Swagger 2.0 includes several properties to describe the service itself. These can all be provided through the configuration API:
 
     httpConfiguration
         .EnableSwagger(c =>
@@ -124,7 +124,7 @@ If schemes are not explicitly provided in a Swagger 2.0 document, then the schem
 
 Use this to describe a single version API. Swagger 2.0 includes an "Info" object to hold additional metadata for an API. Version and title are required but you may also provide additional fields as shown above.
 
-__NOTE__: If you're WebApi is hosted in IIS, you should avoid using full-stops in the version name (e.g. "1.0"). The full-stop at the tail of the URL will cause IIS to treat it as a static file (i.e. with an extension) and bypass the URL Routing Module and therefore, WebApi. 
+__NOTE__: If your Web API is hosted in IIS, you should avoid using full-stops in the version name (e.g. "1.0"). The full-stop at the tail of the URL will cause IIS to treat it as a static file (i.e. with an extension) and bypass the URL Routing Module and therefore, Web API. 
 
 ### Describing Multiple API Versions ###
 
@@ -207,7 +207,7 @@ __NOTE__: If you want to omit specific operations but without using the Obsolete
 
 #### GroupActionsBy ####
 
-Each operation can be assigned one or more tags which are then used by consumers for various reasons. For example, the swagger-ui groups operations according to the first tag of each operation. By default, this will be controller name but you can use this method to override with any value.
+Each operation can be assigned one or more tags which are then used by consumers for various reasons. For example, the swagger-ui groups operations according to the first tag of each operation. By default, this will be the controller name but you can use this method to override with any value.
 
 #### OrderActionGroupsBy ####
 
@@ -323,7 +323,7 @@ You can enable this by providing the path to one or more XML comments files:
                 c.IncludeXmlComments(GetXmlCommentsPathForModels());
             });
 
-NOTE: You will need enable the output of the XML documentation file. This is enabled by going to project properties -> Build -> Output. The "XML documentation file" needs checked and a path assigned such as "bin\Debug\MyProj.XML" you will also want to verify this across each build configuration. Here's an example of reading the file but it may need modified based upon your specific project settings:
+NOTE: You will need to enable output of the XML documentation file. This is enabled by going to project properties -> Build -> Output. The "XML documentation file" needs to be checked and a path assigned, such as "bin\Debug\MyProj.XML". You will also want to verify this across each build configuration. Here's an example of reading the file, but it may need to be modified according to your specific project settings:
 
     httpConfiguration
         .EnableSwagger(c =>
@@ -347,7 +347,7 @@ Swashbuckle will automatically create a "success" response for each operation ba
 
 ### Working Around Swagger 2.0 Constraints ###
 
-In contrast to WebApi, Swagger 2.0 does not include the query string component when mapping a URL to an action. As a result, Swashbuckle will raise an exception if it encounters multiple actions with the same path (sans query string) and HTTP method. You can workaround this by providing a custom strategy to pick a winner or merge the descriptions for the purposes of the Swagger docs 
+In contrast to Web API, Swagger 2.0 does not include the query string component when mapping a URL to an action. As a result, Swashbuckle will raise an exception if it encounters multiple actions with the same path (sans query string) and HTTP method. You can workaround this by providing a custom strategy to pick a winner or merge the descriptions for the purposes of the Swagger docs 
 
     httpConfiguration
         .EnableSwagger((c) =>
@@ -356,17 +356,17 @@ In contrast to WebApi, Swagger 2.0 does not include the query string component w
                 c.ResolveConflictingActions(apiDescriptions => apiDescriptions.First());
             });
 
-See the following discusssion for more details:
+See the following discussion for more details:
 
 <https://github.com/domaindrivendev/Swashbuckle/issues/142>
 
 ## Customizing the swagger-ui ##
 
-The swagger-ui is a JavaScript application hosted in a single HTML page (index.html), and it exposes several customization settings. Swashbuckle ships with an embedded version and includes corresponding config. methods for each of the UI settings. If you require further customization, you can also inject your own version of "index.html". Read on to learn more.
+The swagger-ui is a JavaScript application hosted in a single HTML page (index.html), and it exposes several customization settings. Swashbuckle ships with an embedded version and includes corresponding configuration methods for each of the UI settings. If you require further customization, you can also inject your own version of "index.html". Read on to learn more.
 
-### Customizations via Config. Interface ###
+### Customizations via the configuration API ###
 
-If your happy with the basic look and feel but want to make some minor tweaks, the following options may be sufficient:
+If you're happy with the basic look and feel but want to make some minor tweaks, the following options may be sufficient:
 
     httpConfiguration
         .EnableSwagger(c => c.SingleApiVersion("v1", "A title for your API")) co
@@ -386,11 +386,11 @@ If your happy with the basic look and feel but want to make some minor tweaks, t
 
 #### InjectStylesheet ####
 
-Use this to enrich the UI with one or more additional CSS stylesheets. The file must be included in your project as an "Embedded Resource", and then the resource's "Logical Name" is passed to the method as shown above. See [Injecting Custom Content](#injecting-custom-content) for step by step instructions.
+Use this to enrich the UI with one or more additional CSS stylesheets. The file(s) must be included in your project as an "Embedded Resource", and then the resource's "Logical Name" is passed to the method as shown above. See [Injecting Custom Content](#injecting-custom-content) for step by step instructions.
 
 #### InjectJavaScript ####
 
-Use this to invoke one or more custom JavaScripts after the swagger-ui has loaded. The file must be included in your project as an "Embedded Resource", and then the resource's "Logical Name" is passed to the method as shown above. See [Injecting Custom Content](#injecting-custom-content) for step by step instructions.
+Use this to invoke one or more custom JavaScripts after the swagger-ui has loaded. The file(s) must be included in your project as an "Embedded Resource", and then the resource's "Logical Name" is passed to the method as shown above. See [Injecting Custom Content](#injecting-custom-content) for step by step instructions.
 
 #### BooleanValues ####
 
@@ -421,18 +421,18 @@ For compatibility, you should base your custom "index.html" off [this version](h
 
 The __InjectStylesheet__, __InjectJavaScript__ and __CustomAsset__ options all share the same mechanism for providing custom content. In each case, the file must be included in your project as an "Embedded Resource". The steps to do this are described below:
 
-1. Add a new file to your WebApi project.
+1. Add a new file to your Web API project.
 2. In Solution Explorer, right click the file and open its properties window. Change the "Build Action" to "Embedded Resource".
 
-This will embed the file in your assembly and register it with a "Logical Name". This can then be passed to the relevant config. method. It's based on the Project's default namespace, file location and file extension. For example, given a default namespace of "YourWebApiProject" and a file located at "/SwaggerExtensions/index.html", then the resource will be assigned the name - "YourWebApiProject.SwaggerExtensions.index.html".
+This will embed the file in your assembly and register it with a "Logical Name". This can then be passed to the relevant configuration method. It's based on the Project's default namespace, file location and file extension. For example, given a default namespace of "YourWebApiProject" and a file located at "/SwaggerExtensions/index.html", then the resource will be assigned the name - "YourWebApiProject.SwaggerExtensions.index.html".
 
 ## Transitioning to Swashbuckle 5.0 ##
 
-This version of Swashbuckle makes the transition to Swagger 2.0. The 2.0 specification is significantly different to its predecessor - 1.2 and forces several breaking changes to Swashbuckle's config. interface. If you're using Swashbuckle without any customizations, i.e. App_Start/SwaggerConfig.cs has never been modified, then you can overwrite it with the new version. The defaults are the same and so the swagger-ui should behave as before.
+This version of Swashbuckle makes the transition to Swagger 2.0. The 2.0 specification is significantly different to its predecessor (1.2) and forces several breaking changes to Swashbuckle's configuration API. If you're using Swashbuckle without any customizations, i.e. App_Start/SwaggerConfig.cs has never been modified, then you can overwrite it with the new version. The defaults are the same and so the swagger-ui should behave as before.
 
 \* If you have consumers of the raw Swagger document, you should ensure they can accept Swagger 2.0 before making the upgrade.
 
-If you're using the existing config. interface to customize the final Swagger document and/or swagger-ui, you will need to port the code manually. The static __Customize__ methods on SwaggerSpecConfig and SwaggerUiConfig have been replaced with extension methods on HttpConfiguration - __EnableSwagger__ and __EnableSwaggerUi__. All options from version 4.0 are made available through these methods, albeit with slightly different naming and syntax. Refer to the tables below for a summary of changes:
+If you're using the existing configuration API to customize the final Swagger document and/or swagger-ui, you will need to port the code manually. The static __Customize__ methods on SwaggerSpecConfig and SwaggerUiConfig have been replaced with extension methods on HttpConfiguration - __EnableSwagger__ and __EnableSwaggerUi__. All options from version 4.0 are made available through these methods, albeit with slightly different naming and syntax. Refer to the tables below for a summary of changes:
 
 
 | 4.0 | 5.0 Equivalant | Additional Notes |
@@ -464,13 +464,13 @@ If you're using the existing config. interface to customize the final Swagger do
 
 If you see this message, it means the swagger-ui received an unexpected response when requesting the Swagger document. You can troubleshoot further by navigating directly to the discovery URL included in the error message. This should provide more details.
 
-If the discovery URL returns a 404 Not Found response, it may be due to a full-stop in the version name (e.g. "1.0"). This will cause IIS to treat it as a static file (i.e. with an extension) and bypass the URL Routing Module and therefore, WebApi. 
+If the discovery URL returns a 404 Not Found response, it may be due to a full-stop in the version name (e.g. "1.0"). This will cause IIS to treat it as a static file (i.e. with an extension) and bypass the URL Routing Module and therefore, Web API. 
 
 To workaround, you can update the version name specified in SwaggerConfig.cs. For example, to "v1", "1-0" etc. Alternatively, you can change the route template being used for the swagger docs (as shown [here](#custom-routes)) so that the version parameter is not at the end of the route.
 
 ### Page not found when accessing the UI ###
 
-Swashbuckle serves an embedded version of the swagger-ui through the WebApi pipeline. But, most of the URL's contain extensions (.html, .js, .css) and many IIS environments are configured to bypass the managed pipeline for paths containing extensions.
+Swashbuckle serves an embedded version of the swagger-ui through the Web API pipeline. But, most of the URLs contain extensions (.html, .js, .css) and many IIS environments are configured to bypass the managed pipeline for paths containing extensions.
 
 In previous versions of Swashbuckle, this was resolved by adding the following setting to your Web.config:
 
@@ -480,21 +480,21 @@ In previous versions of Swashbuckle, this was resolved by adding the following s
 
 This is no longer neccessary in Swashbuckle 5.0 because it serves the swagger-ui through extensionless URL's.
 
-However, if you're using the SingleApiVersion, MultipleApiVersions or CustomAsset config. settings you could still get this error. Check to ensure you're not specifying a value that causes a URL with extension to be referenced in the UI. For example a full-stop in a version number ...
+However, if you're using the SingleApiVersion, MultipleApiVersions or CustomAsset configuration settings you could still get this error. Check to ensure you're not specifying a value that causes a URL with an extension to be referenced in the UI. For example a full-stop in a version number ...
 
     httpConfiguration
         .EnableSwagger(c => c.SingleApiVersion("1.0", "A title for your API"))
         .EnableSwaggerUi();
 
-Will result in a discovery URL like this "/swagger/docs/1.0" where the full-stop is treated as a file extension.
+will result in a discovery URL like this "/swagger/docs/1.0" where the full-stop is treated as a file extension.
 
 ### Swagger-ui broken by Visual Studio 2013 ###
 
-VS 2013 ships with a new feature - Browser Link that improves the web development workflow by setting up a channel between the IDE and pages being previewed in a local browser. It does this by dynamically injecting JavaScript into your files.
+VS 2013 ships with a new feature - Browser Link - that improves the web development workflow by setting up a channel between the IDE and pages being previewed in a local browser. It does this by dynamically injecting JavaScript into your files.
 
 Although this JavaScript SHOULD have no affect on your production code, it appears to be breaking the swagger-ui.
 
-I hope to find a permanent fix but in the meantime, you'll need to workaround this isuse by disabling the feature in your web.config:
+I hope to find a permanent fix, but in the meantime, you'll need to workaround this issue by disabling the feature in your web.config:
 
     <appSettings>
         <add key="vs:EnableBrowserLink" value="false"/>
@@ -502,7 +502,7 @@ I hope to find a permanent fix but in the meantime, you'll need to workaround th
 
 ### OWIN Hosted in IIS - Incorrect VirtualPathRoot Handling
 
-When you host WebApi 2 on top of OWIN/SystemWeb, Swashbuckle cannot correctly resolve VirtualPathRoot by default.
+When you host Web API 2 on top of OWIN/SystemWeb, Swashbuckle cannot correctly resolve VirtualPathRoot by default.
 
 You must either explicitly set VirtualPathRoot in your HttpConfiguration at startup, or perform customization like this to fix automatic discovery:
 


### PR DESCRIPTION
Also changed "WebApi" to "Web API", since that's the official name (it's very generic, but that's how it is).

"config. interface" changed to "configuration API", since "interface" in some places sounded more like a GUI thing.