### PR TITLE
Fixes null ref exception when a generic type 'T' is passed in.

### DIFF
--- a/Swashbuckle.Core/Swagger/TypeExtensions.cs
+++ b/Swashbuckle.Core/Swagger/TypeExtensions.cs
@@ -29,6 +29,8 @@ namespace Swashbuckle.Swagger
         public static string FullNameSansTypeParameters(this Type type)
         {
             var fullName = type.FullName;
+            if (string.IsNullOrEmpty(fullName))
+                fullName = type.Name;
             var chopIndex = fullName.IndexOf("[[");
             return (chopIndex == -1) ? fullName : fullName.Substring(0, chopIndex);
         }


### PR DESCRIPTION
The issue is encountered when using generic types in MVC controllers. Tested.