### PR TITLE
Fix custom route sample mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The default route templates for the Swagger docs and swagger-ui are "swagger/doc
         .EnableSwagger("docs/{apiVersion}/swagger", c => c.SingleApiVersion("v1", "A title for your API"))
         .EnableSwaggerUi("sandbox/{*assetPath}");
 
-In this case the URL to swagger-ui will be `sandbox/ui/index`.
+In this case the URL to swagger-ui will be `sandbox/index`.
 
 ### Additional Service Metadata ###
 


### PR DESCRIPTION
Custom routes section contained wrong description about swagger-ui route.
in case when you EnableSwaggerUi("sandbox/{*assetPath}") the correct url will be 'sandbox/index'