### PR TITLE
Support additional query parameters during OAuth2 authorization process

### DIFF
--- a/Swashbuckle.Core/Application/SwaggerUiConfig.cs
+++ b/Swashbuckle.Core/Application/SwaggerUiConfig.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
+using Newtonsoft.Json;
 using Swashbuckle.SwaggerUi;
 
 namespace Swashbuckle.Application
@@ -99,18 +100,19 @@ namespace Swashbuckle.Application
             InjectJavaScript(GetType().Assembly, "Swashbuckle.SwaggerUi.CustomAssets.discoveryUrlSelector.js");
         }
 
-        public void EnableOAuth2Support(string clientId, string realm, string appName)
+        public void EnableOAuth2Support(string clientId, string realm, string appName, Dictionary<string, string> additionalQueryStringParams = null)
         {
-            EnableOAuth2Support(clientId, "N/A", realm, appName);
+            EnableOAuth2Support(clientId, "N/A", realm, appName, additionalQueryStringParams);
         }
 
-        public void EnableOAuth2Support(string clientId, string clientSecret, string realm, string appName)
+        public void EnableOAuth2Support(string clientId, string clientSecret, string realm, string appName, Dictionary<string, string> additionalQueryStringParams = null)
         {
             _templateParams["%(OAuth2Enabled)"] = "true";
             _templateParams["%(OAuth2ClientId)"] = clientId;
             _templateParams["%(OAuth2ClientSecret)"] = clientSecret;
             _templateParams["%(OAuth2Realm)"] = realm;
             _templateParams["%(OAuth2AppName)"] = appName;
+            _templateParams["%(oAuth2AdditionalQueryStringParams)"] = JsonConvert.SerializeObject(additionalQueryStringParams ?? new Dictionary<string, string>());
         }
 
         internal IAssetProvider GetSwaggerUiProvider()

--- a/Swashbuckle.Core/SwaggerUi/CustomAssets/index.html
+++ b/Swashbuckle.Core/SwaggerUi/CustomAssets/index.html
@@ -57,7 +57,8 @@
         oAuth2ClientId: '%(OAuth2ClientId)',
         oAuth2ClientSecret: '%(OAuth2ClientSecret)',
         oAuth2Realm: '%(OAuth2Realm)',
-        oAuth2AppName: '%(OAuth2AppName)'
+        oAuth2AppName: '%(OAuth2AppName)',
+        oAuth2AdditionalQueryStringParams: JSON.parse('%(oAuth2AdditionalQueryStringParams)')
       };
 
       // Pre load translate...
@@ -75,7 +76,8 @@
               clientSecret: swashbuckleConfig.oAuth2ClientSecret,
               realm: swashbuckleConfig.oAuth2Realm,
               appName: swashbuckleConfig.oAuth2AppName,
-              scopeSeparator: ","
+              scopeSeparator: ",",
+              additionalQueryStringParams: swashbuckleConfig.oAuth2AdditionalQueryStringParams
             });
           }
 

--- a/Swashbuckle.Core/SwaggerUi/CustomAssets/swagger-oauth.js
+++ b/Swashbuckle.Core/SwaggerUi/CustomAssets/swagger-oauth.js
@@ -7,6 +7,7 @@ var oauth2KeyName;
 var redirect_uri;
 var clientSecret;
 var scopeSeparator;
+var additionalQueryStringParams;
 
 function handleLogin() {
   var scopes = [];
@@ -156,6 +157,9 @@ function handleLogin() {
     url += '&client_id=' + encodeURIComponent(clientId);
     url += '&scope=' + encodeURIComponent(scopes.join(scopeSeparator));
     url += '&state=' + encodeURIComponent(state);
+    for (var key in additionalQueryStringParams) {
+        url += '&' + key + '=' + encodeURIComponent(additionalQueryStringParams[key]);
+    }
 
     window.open(url);
   });
@@ -190,6 +194,7 @@ function initOAuth(opts) {
   clientSecret = (o.clientSecret||errors.push('missing client secret'));
   realm = (o.realm||errors.push('missing realm'));
   scopeSeparator = (o.scopeSeparator||' ');
+  additionalQueryStringParams = (o.additionalQueryStringParams||{});
 
   if(errors.length > 0){
     log('auth unable initialize oauth: ' + errors);

--- a/Swashbuckle.Tests/SwaggerUi/SwaggerUiTests.cs
+++ b/Swashbuckle.Tests/SwaggerUi/SwaggerUiTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Net;
 using NUnit.Framework;
@@ -75,14 +76,21 @@ namespace Swashbuckle.Tests.SwaggerUi
         [Test]
         public void It_exposes_config_for_swagger_ui_outh2_settings()
         {
-            SetUpHandler(c => c.EnableOAuth2Support("test-client-id", "test-realm", "Swagger UI"));
+            SetUpHandler(c => c.EnableOAuth2Support(
+                "test-client-id",
+                "test-client-secret",
+                "test-realm",
+                "Swagger UI",
+                new Dictionary<string, string> {{"TestHeader", "TestValue"}}));
 
             var content = GetContentAsString("http://tempuri.org/swagger/ui/index");
 
             StringAssert.Contains("oAuth2Enabled: ('true' == 'true')", content);
             StringAssert.Contains("oAuth2ClientId: 'test-client-id'", content);
+            StringAssert.Contains("oAuth2ClientSecret: 'test-client-secret'", content);
             StringAssert.Contains("oAuth2Realm: 'test-realm'", content);
             StringAssert.Contains("oAuth2AppName: 'Swagger UI'", content);
+            StringAssert.Contains("oAuth2AdditionalQueryStringParams: JSON.parse('{\"TestHeader\":\"TestValue\"}')", content);
         }
 
         [Test]


### PR DESCRIPTION
Hi, while trying to integrate an Azure Active Directory (AAD) protected API with Swashbuckle and Swagger-UI I encountered the issue where it is required to specify the "Resource" parameter during OAuth2 authorization but there was no way of easily providing it. This problem is covered in issues https://github.com/domaindrivendev/Swashbuckle/issues/465 and https://github.com/swagger-api/swagger-ui/issues/1302.

I made a generic mechanism for passing custom parameters (instead of adding a specific "Resource" parameter) since I also really needed a custom parameter "domain_hint" as explained here - http://www.cloudidentity.com/blog/2014/11/17/skipping-the-home-realm-discovery-page-in-azure-ad/.

This change corresponds to a pull request on Swagger-UI I opened as well (https://github.com/swagger-api/swagger-ui/pull/1648). However, incorporating this change into Swashbuckle requires placing it in the Swagger-UI custom assets anyway so it doesn't rely on that Pull Request being pulled first.
I'd appreciate it if this addition can be merged into Swashbuckle. Thanks!