### PR TITLE
Cater for value names defined in EnumMember attributes

### DIFF
--- a/Swashbuckle.Core/Swashbuckle.Core.csproj
+++ b/Swashbuckle.Core/Swashbuckle.Core.csproj
@@ -59,6 +59,7 @@
     <Reference Include="System.Net.Http.WebRequest, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Net.Http.2.0.20710.0\lib\net40\System.Net.Http.WebRequest.dll</HintPath>
     </Reference>
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Web.Http, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.4.0.20710.0\lib\net40\System.Web.Http.dll</HintPath>
     </Reference>

--- a/Swashbuckle.Dummy.Core/Controllers/DataContractAnnotatedTypesController.cs
+++ b/Swashbuckle.Dummy.Core/Controllers/DataContractAnnotatedTypesController.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Runtime.Serialization;
+using System.Web.Http;
+
+namespace Swashbuckle.Dummy.Controllers
+{
+    public class DataContractAnnotatedTypesController : ApiController
+    {
+        public int Create(DataContractRequest request)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class DataContractRequest
+    {
+        public DataContractEnumWithOutValues OverriddenValues { get; set; }
+        public DataContractEnumWithValues RawValues { get; set; }
+    }
+
+    [DataContract]
+    public enum DataContractEnumWithValues
+    {
+        [EnumMember(Value = "aie")]
+        A = 2,
+        [EnumMember(Value = "bee")]
+        B = 4
+    }
+
+    [DataContract]
+    public enum DataContractEnumWithOutValues
+    {
+        [EnumMember]
+        A = 2,
+        [EnumMember]
+        B = 4
+    }
+}

--- a/Swashbuckle.Dummy.Core/Swashbuckle.Dummy.Core.csproj
+++ b/Swashbuckle.Dummy.Core/Swashbuckle.Dummy.Core.csproj
@@ -49,6 +49,7 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.2\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Web.Cors">
       <HintPath>..\packages\Microsoft.AspNet.Cors.5.0.0\lib\net45\System.Web.Cors.dll</HintPath>
     </Reference>
@@ -65,6 +66,7 @@
     <Compile Include="App_Start\CachingSwaggerProvider.cs" />
     <Compile Include="App_Start\CustomCorsPolicyProvider.cs" />
     <Compile Include="Controllers\ConflictingTypesController.cs" />
+    <Compile Include="Controllers\DataContractAnnotatedTypesController.cs" />
     <Compile Include="Controllers\FileDownloadController.cs" />
     <Compile Include="Controllers\FileUploadController.cs" />
     <Compile Include="Controllers\FromUriParamsContoller.cs" />


### PR DESCRIPTION
This is one option for fixing #562 

I think the best way would be to rely on json.net's serializer to format the name, falling back to the current implementation if one isn't available - the problem is I couldn't spot an easy way to do that.

This is probably the "next best" option - rather using type.GetEnumNames, implement a new GetEnumNames method that is similar, but has some understanding of the EnumValue attribute. The main drawback is the new dependency on System.Runtime.Serialization, but given you're relying on JSON.NET you've already got an indirect dependency there.

Hope that helps.