### PR TITLE
Trim leading XML spaces, use '.' for leading padding.

### DIFF
--- a/Swashbuckle.Core/Swagger/XmlComments/XPathNavigatorExtensions.cs
+++ b/Swashbuckle.Core/Swagger/XmlComments/XPathNavigatorExtensions.cs
@@ -12,14 +12,15 @@ namespace Swashbuckle.Swagger.XmlComments
     {
         private static Regex ParamPattern = new Regex(@"<(see|paramref) (name|cref)=""([TPF]{1}:)?(?<display>.+?)"" />");
         private static Regex ConstPattern = new Regex(@"<c>(?<display>.+?)</c>");
-
+        private static Regex XmlNewLinePadding = new Regex(@"^(?<padding>[\t\v\f \u00a0\u2000-\u200b\u2028-\u2029\u3000]+)(?<force>\.?)(?<line>.*)$", RegexOptions.Multiline);
         public static string ExtractContent(this XPathNavigator node)
         {
             if (node == null) return null;
 
-            return ConstPattern.Replace(
+            return XmlNewLinePadding.Replace(ConstPattern.Replace(
                 ParamPattern.Replace(node.InnerXml, GetParamRefName),
-                GetConstRefName).Trim();
+                GetConstRefName).Trim(), GetNewLinePadding);
+
         }
 
         private static string GetConstRefName(Match match)
@@ -35,5 +36,13 @@ namespace Swashbuckle.Swagger.XmlComments
 
             return "{" + match.Groups["display"].Value + "}";
         }
+
+        private static string GetNewLinePadding(Match match)
+        {
+            if (match.Groups.Count != 4) return null;
+
+            return (match.Groups["force"].Value == "." ? " " : string.Empty) + match.Groups["line"].Value;
+        }
+
     }
 }

--- a/Swashbuckle.Dummy.Core/Controllers/XmlAnnotatedController.cs
+++ b/Swashbuckle.Dummy.Core/Controllers/XmlAnnotatedController.cs
@@ -87,6 +87,21 @@ namespace Swashbuckle.Dummy.Controllers
         {
             throw new NotImplementedException();
         }
+
+        /// <summary>
+        /// Markdown Indention Tests
+        /// </summary>
+        /// <remarks>First Line after remarks tag
+        /// Second no additional space
+        ///      Third with extra leading spaces (that should be ignored)
+        ///      
+        /// .    Fourth with intentional leading spaces</remarks>
+        [HttpGet]
+        [Route("markdown")]
+        public void MarkDownTest()
+        {
+
+        }
     }
 
     public class Page

--- a/Swashbuckle.Dummy.Core/XmlComments.xml
+++ b/Swashbuckle.Dummy.Core/XmlComments.xml
@@ -53,6 +53,16 @@
             <param name="id"></param>
             <param name="metadata"></param>
         </member>
+        <member name="M:Swashbuckle.Dummy.Controllers.XmlAnnotatedController.MarkDownTest">
+            <summary>
+            Markdown Indention Tests
+            </summary>
+            <remarks>First Line after remarks tag
+            Second no additional space
+                 Third with extra leading spaces (that should be ignored)
+                 
+            .    Fourth with intentional leading spaces</remarks>
+        </member>
         <member name="P:Swashbuckle.Dummy.Controllers.Page.Limit">
             <summary>
             The maximum number of accounts to return

--- a/Swashbuckle.Dummy.WebHost/XmlComments.xml
+++ b/Swashbuckle.Dummy.WebHost/XmlComments.xml
@@ -53,6 +53,16 @@
             <param name="id"></param>
             <param name="metadata"></param>
         </member>
+        <member name="M:Swashbuckle.Dummy.Controllers.XmlAnnotatedController.MarkDownTest">
+            <summary>
+            Markdown Indention Tests
+            </summary>
+            <remarks>First Line after remarks tag
+            Second no additional space
+                 Third with extra leading spaces (that should be ignored)
+                 
+            .    Fourth with intentional leading spaces</remarks>
+        </member>
         <member name="P:Swashbuckle.Dummy.Controllers.Page.Limit">
             <summary>
             The maximum number of accounts to return

--- a/Swashbuckle.Tests/Swagger/XmlCommentsTests.cs
+++ b/Swashbuckle.Tests/Swagger/XmlCommentsTests.cs
@@ -208,5 +208,18 @@ namespace Swashbuckle.Tests.Swagger
             var valueProperty = swagger["definitions"]["Reward[String]"]["properties"]["value"];
             Assert.IsNull(valueProperty["description"]);
         }
+
+        [Test]
+        public void It_trims_leading_spaces_on_comments()
+        {
+            var swagger = GetContent<JObject>("http://tempuri.org/swagger/docs/v1");
+            var description = swagger["paths"]["/xmlannotated/markdown"]["get"]["description"].ToString();
+            Assert.AreEqual(@"First Line after remarks tag
+Second no additional space
+Third with extra leading spaces (that should be ignored)
+
+     Fourth with intentional leading spaces", description);
+            
+        }
     }
 }


### PR DESCRIPTION
Fixes #258. By trimming leading spaces from XML comments, markdown should function correctly.  

_Even when text is placed flush up against the xml comment tag `///` the resulting xml document has leading spaces due to hierarchical indentation._

For those cases where leading spaces are desired, '.' can be used to force them.

```c#
        /// <summary>
        /// Markdown Indention Tests
        /// </summary>
        /// <remarks>First Line after remarks tag
        /// Second no additional space
        ///      Third with extra leading spaces (that should be ignored)
        ///
        /// .    Fourth with intentional leading spaces
        /// </remarks>
```

Should Result in a Swagger description of:

```
First Line after remarks tag
Second no additional space
Third with extra leading spaces (that should be ignored)

    Fourth with intentional leading spaces
```