### PR TITLE
Add non-generic overload of SwaggerDocsConfig.MapType, issue #643

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ _ReSharper.*
 *.dotCover
 *.dotsettings
 !*.proj
+
+# Visual Studio 2015 cache/options directory
+.vs/

--- a/Swashbuckle.Core/Application/SwaggerDocsConfig.cs
+++ b/Swashbuckle.Core/Application/SwaggerDocsConfig.cs
@@ -125,7 +125,12 @@ namespace Swashbuckle.Application
 
         public void MapType<T>(Func<Schema> factory)
         {
-            _customSchemaMappings.Add(typeof(T), factory);
+            MapType(typeof(T), factory);
+        }
+
+        public void MapType(Type type, Func<Schema> factory)
+        {
+            _customSchemaMappings.Add(type, factory);
         }
 
         public void SchemaFilter<TFilter>()


### PR DESCRIPTION
Overload added. I didn't write any tests, because it seemed not reasonable to duplicate existing tests and I am not aware of any better way. Let me know if you would like to add some tests and I will take care of it.