### PR TITLE
Handle Dictionary with enum as key

### DIFF
--- a/Swashbuckle.Core/Swagger/SchemaRegistry.cs
+++ b/Swashbuckle.Core/Swagger/SchemaRegistry.cs
@@ -165,23 +165,14 @@ namespace Swashbuckle.Swagger
 
         private Schema CreateEnumSchema(JsonPrimitiveContract primitiveContract, Type type)
         {
-            var stringEnumConverter = primitiveContract.Converter as StringEnumConverter
-                ?? _jsonSerializerSettings.Converters.OfType<StringEnumConverter>().FirstOrDefault();
-
-            if (_describeAllEnumsAsStrings || stringEnumConverter != null)
-            {
-                var camelCase = _describeStringEnumsInCamelCase
-                    || (stringEnumConverter != null && stringEnumConverter.CamelCaseText);
-
+            string[] enumValues;
+            if (TryGetEnumStringValues(primitiveContract, type, out enumValues))
                 return new Schema
                 {
                     type = "string",
-                    @enum = camelCase
-                        ? type.GetEnumNamesForSerialization().Select(name => name.ToCamelCase()).ToArray()
-                        : type.GetEnumNamesForSerialization()
+                    @enum = enumValues
                 };
-            }
-            
+
             return new Schema
             {
                 type = "integer",
@@ -190,14 +181,50 @@ namespace Swashbuckle.Swagger
             };
         }
 
+        private bool TryGetEnumStringValues(JsonContract contract, Type type, out string[] enumValues)
+        {
+            enumValues = null;
+            var stringEnumConverter = contract.Converter as StringEnumConverter
+                                      ?? _jsonSerializerSettings.Converters.OfType<StringEnumConverter>().FirstOrDefault();
+
+            if (_describeAllEnumsAsStrings || stringEnumConverter != null)
+            {
+                var camelCase = _describeStringEnumsInCamelCase
+                                || (stringEnumConverter != null && stringEnumConverter.CamelCaseText);
+
+                enumValues = camelCase
+                    ? type.GetEnumNamesForSerialization().Select(name => name.ToCamelCase()).ToArray()
+                    : type.GetEnumNamesForSerialization();
+
+                return true;
+            }
+            return false;
+        }
+
         private Schema CreateDictionarySchema(JsonDictionaryContract dictionaryContract)
         {
             var valueType = dictionaryContract.DictionaryValueType ?? typeof(object);
-            return new Schema
+
+            string[] enumValues;
+            if (dictionaryContract.DictionaryKeyType.IsEnum 
+                && TryGetEnumStringValues(dictionaryContract, dictionaryContract.DictionaryKeyType, out enumValues))
+            {
+                var properties = enumValues.ToDictionary(
+                    prop => prop,
+                    prop => CreateInlineSchema(dictionaryContract.DictionaryValueType)
+                    );
+                return new Schema
                 {
                     type = "object",
-                    additionalProperties = CreateInlineSchema(valueType)
+                    properties = properties
                 };
+            }
+
+            return new Schema
+            {
+                type = "object",
+                additionalProperties = CreateInlineSchema(valueType)
+            };
         }
 
         private Schema CreateArraySchema(JsonArrayContract arrayContract)

--- a/Swashbuckle.Dummy.Core/Controllers/DictionaryController.cs
+++ b/Swashbuckle.Dummy.Core/Controllers/DictionaryController.cs
@@ -1,0 +1,32 @@
+﻿using Swashbuckle.Dummy.SwaggerExtensions;
+using System;
+using System.Collections.Generic;
+using System.Web.Http;
+
+namespace Swashbuckle.Dummy.Controllers
+{
+    public class DictionaryController : ApiController
+    {
+        [HttpGet]
+        public IEnumerable<ItemWithDictionary> Get()
+        {
+            throw new NotImplementedException();
+        }
+    }
+    
+    public class ItemWithDictionary
+    {
+        public IDictionary<KeyType, SimpleValue> Values { get; set; }	
+    }
+
+    public class SimpleValue
+    {
+        public string Name { get; set; }
+    }
+
+    public enum KeyType
+    {
+        KeyOne,
+        KeyTwo,
+    }
+}

--- a/Swashbuckle.Dummy.Core/Swashbuckle.Dummy.Core.csproj
+++ b/Swashbuckle.Dummy.Core/Swashbuckle.Dummy.Core.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Controllers\NullableTypesController.cs" />
     <Compile Include="Controllers\ObsoletePropertiesController.cs" />
     <Compile Include="Controllers\PathRequiredController.cs" />
+    <Compile Include="Controllers\DictionaryController.cs" />
     <Compile Include="Controllers\ProtectedResourcesController.cs" />
     <Compile Include="Controllers\SelfReferencingTypesController.cs" />
     <Compile Include="Controllers\CustomersController.cs" />

--- a/Swashbuckle.Tests/Swagger/SchemaTests.cs
+++ b/Swashbuckle.Tests/Swagger/SchemaTests.cs
@@ -538,5 +538,50 @@ namespace Swashbuckle.Tests.Swagger
 
             Assert.IsTrue(required);
         }
+
+        [Test]
+        public void It_handle_dictionary_when_json_string_enum_converter_configured()
+        {
+            Configuration.Formatters.JsonFormatter.SerializerSettings.Converters.Add(
+                new StringEnumConverter { CamelCaseText = true });
+            SetUpDefaultRouteFor<DictionaryController>();
+
+            var swagger = GetContent<JObject>("http://tempuri.org/swagger/docs/v1");
+            var typeSchema = swagger["definitions"];
+
+            var valueDefinition = JObject.Parse("{ $ref: \"#/definitions/SimpleValue\" }");
+            var expected = JObject.FromObject(new
+            {
+                ItemWithDictionary = new
+                {
+                    type = "object",
+                    properties = new
+                    {
+                        Values = new
+                        {
+                            type = "object",
+                            properties = new
+                            {
+                                keyOne = valueDefinition,
+                                keyTwo = valueDefinition
+                            }
+                        }
+                    }
+                },
+                SimpleValue = new
+                {
+                    type = "object",
+                    properties = new
+                    {
+                        Name = new
+                        {
+                            type = "string"
+                        }
+                    }
+                }
+            });
+
+            Assert.AreEqual(expected.ToString(), typeSchema.ToString());
+        }
     }
 }


### PR DESCRIPTION
This feature is enabled only when Enum are serialized as string (using _StringEnumConverter_).

As the key is an Enum, the list of all possible keys is known, hence it's possible to describe all the object properties, assuming they are all optional.

This implement the feature I requested in #676 

So for example if you have _ItemWithDictionary_ as following:

```c#
    public class ItemWithDictionary
    {
        public IDictionary<KeyType, SimpleValue> Values { get; set; }	
    }

    public class SimpleValue
    {
        public string Name { get; set; }
    }

    public enum KeyType
    {
        KeyOne,
        KeyTwo,
    }
```

it will be generated as 
```YAML
  ItemWithDictionary:
    type: object
    properties:
      Values:
        type: object
        properties:
          keyOne:
            $ref: '#/definitions/SimpleValue'
          keyTwo:
            $ref: '#/definitions/SimpleValue'
```

Please let me know if it is worth merging and it requires some polishing.

Thanks,
 Alessio