### PR TITLE
Set format to 'uuid' for System.Guid

### DIFF
--- a/Swashbuckle.Core/Swagger/SchemaRegistry.cs
+++ b/Swashbuckle.Core/Swagger/SchemaRegistry.cs
@@ -158,6 +158,8 @@ namespace Swashbuckle.Swagger
                 case "System.DateTime":
                 case "System.DateTimeOffset":
                     return new Schema { type = "string", format = "date-time" };
+                case "System.Guid":
+                    return new Schema { type = "string", format = "uuid" };
                 default:
                     return new Schema { type = "string" };
             }


### PR DESCRIPTION
In Swagger, GUIDs/UUIDs can have the custom format "uuid" specified so that the appropriate language primitive can be used when generating code. For example, in the C# Swagger generator, this will cause the generated property to have type System.Guid instead of System.String: https://github.com/swagger-api/swagger-codegen/blob/b00971edc9005a7c2c95d8c9f87beb1b1153a962/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractCSharpCodegen.java#L117
The same also applies to the Java generator.

This pull request simply adds that mapping to Swashbuckle's schema generator.