### PR TITLE
#718 Adding support for having multiple swagger endpoints

### DIFF
--- a/Swashbuckle.Core/Application/HttpConfigurationExtensions.cs
+++ b/Swashbuckle.Core/Application/HttpConfigurationExtensions.cs
@@ -30,7 +30,7 @@ namespace Swashbuckle.Application
             if (configure != null) configure(config);
 
             httpConfig.Routes.MapHttpRoute(
-                name: "swagger_docs",
+                name: "swagger_docs" + routeTemplate,
                 routeTemplate: routeTemplate,
                 defaults: null,
                 constraints: new { apiVersion = @".+" },
@@ -84,7 +84,7 @@ namespace Swashbuckle.Application
             if (configure != null) configure(config);
 
             _httpConfig.Routes.MapHttpRoute(
-                name: "swagger_ui",
+                name: "swagger_ui" + routeTemplate,
                 routeTemplate: routeTemplate,
                 defaults: null,
                 constraints: new { assetPath = @".+" },

--- a/Swashbuckle.Tests/Owin/BaseInMemoryOwinSwaggerTest.cs
+++ b/Swashbuckle.Tests/Owin/BaseInMemoryOwinSwaggerTest.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Owin.Testing;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using Owin;
+
+namespace Swashbuckle.Tests.Owin
+{
+    [TestFixture]
+    public abstract class BaseInMemoryOwinSwaggerTest
+    {
+        protected HttpClient _client;
+        private IDisposable _server;
+
+        /// <summary>
+        /// Generates swagger documentation only for specific controllers.
+        /// </summary>
+        /// <param name="controllerType"></param>
+        protected void UseInMemoryOwinServer(params Type[] controllerType)
+        {
+            ConfigureInMemoryOwinServer(appBuilder => ConfigureOwinStartup(controllerType, appBuilder));
+        }
+
+        protected void UseInMemoryOwinServer(Action<IAppBuilder> owinStartupBuilder)
+        {
+            ConfigureInMemoryOwinServer(appBuilder => owinStartupBuilder(appBuilder));
+        }
+
+        private void ConfigureOwinStartup(Type[] controller, IAppBuilder appBuilder)
+        {
+            new OwinStartup(controller).Configuration(appBuilder);
+        }
+
+        private void ConfigureInMemoryOwinServer(Action<IAppBuilder> appBuilder)
+        {
+            var testServer = TestServer.Create(appBuilder);
+            _client = testServer.HttpClient;
+            _server = testServer;
+        }
+
+        [TestFixtureTearDown]
+        public void TeardownFixture()
+        {
+            _server?.Dispose();
+            _server = null;
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            _server?.Dispose();
+            _server = null;
+        }
+
+        protected async Task<JObject> GetSwaggerDocs()
+        {
+            return await GetContent("swagger/docs/v1");
+        }
+
+        protected async Task<JObject> GetContent(string uri)
+        {
+            var response = await _client.GetAsync(uri);
+            if (response.IsSuccessStatusCode == false)
+                Assert.Fail("Failed request to {0}: Status code: {1} {2}", uri, response.StatusCode.ToString(), response.ReasonPhrase);
+            var content = await response.Content.ReadAsAsync<JObject>();
+            return content;
+
+        }
+    }
+}

--- a/Swashbuckle.Tests/Owin/InMemoryOwinTest.cs
+++ b/Swashbuckle.Tests/Owin/InMemoryOwinTest.cs
@@ -1,0 +1,63 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web.Http;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace Swashbuckle.Tests.Owin
+{
+    [TestFixture]
+    public class InMemoryOwinTest : BaseInMemoryOwinSwaggerTest
+    {
+        [RoutePrefix("v1/callback")]
+        [AllowAnonymous]
+        public class CallbackController : ApiController
+        {
+            [Route, HttpGet]
+            public HttpResponseMessage Get()
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.OK);
+                response.Content = new StringContent("{key:1}", Encoding.UTF8, "application/json");
+                return response;
+            }
+        }
+
+        [Test]
+        public async Task It_supports_configuring_single_swagger_endpoint()
+        {
+            // Given
+            UseInMemoryOwinServer(app => new OwinStartup(typeof(CallbackController)).Configuration(app));
+
+            // When
+            var swagger = await GetSwaggerDocs();
+
+            // Then
+            var postResponses = swagger["paths"]["/v1/callback"]["get"]["operationId"];
+
+            Assert.That(postResponses.Value<string>(), Is.EqualTo("Callback_Get"));
+        }
+
+        [Test]
+        public async Task It_supports_configuring_multiple_swagger_endpoints()
+        {
+            // Given
+            UseInMemoryOwinServer(app => new MultiSwaggerOwinStartup(typeof(CallbackController)).Configuration(app));
+
+            // When, 
+            var swaggerRoot = await GetSwaggerDocs();
+
+            // Then
+            var postResponses = swaggerRoot["paths"]["/v1/callback"]["get"]["operationId"];
+            Assert.That(postResponses.Value<string>(), Is.EqualTo("Callback_Get"));
+
+            // When, 
+            var swaggerCustom = await GetContent("docs/v1/.metadata");
+
+            // Then
+            postResponses = swaggerCustom["paths"]["/v1/callback"]["get"]["operationId"];
+            Assert.That(postResponses.Value<string>(), Is.EqualTo("Callback_Get"));
+        }
+    }
+}

--- a/Swashbuckle.Tests/Owin/MultiSwaggerOwinStartup.cs
+++ b/Swashbuckle.Tests/Owin/MultiSwaggerOwinStartup.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Web.Http;
+using Swashbuckle.Application;
+
+namespace Swashbuckle.Tests.Owin
+{
+    public class MultiSwaggerOwinStartup : OwinStartup
+    {
+        public MultiSwaggerOwinStartup(params Type[] supportedControllers) : base(supportedControllers)
+        {
+        }
+
+        protected override void EnableSwagger(HttpConfiguration config)
+        {
+            base.EnableSwagger(config);
+
+            // configure swagger as well on separate URL
+            config
+                .EnableSwagger("docs/{apiVersion}/.metadata", c => c.SingleApiVersion("v1", "A title for your API"))
+                .EnableSwaggerUi("docs-ui/{*assetPath}");
+        }
+    }
+}

--- a/Swashbuckle.Tests/Owin/OwinStartup.cs
+++ b/Swashbuckle.Tests/Owin/OwinStartup.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Linq;
+using System.Web.Http;
+using System.Web.Http.Dispatcher;
+using System.Web.Http.Routing;
+using Owin;
+using Swashbuckle.Application;
+
+namespace Swashbuckle.Tests.Owin
+{
+    public class OwinStartup
+    {
+        private Type[] supportedControllers = { };
+        //private Func<IApiExplorer, Func<IOperationFilter>> operationIdFunc;
+
+        /// <summary>
+        /// When developing, it is quicker to run tests scoped to just a list of controllers.
+        /// When running tests in CI, set this to true.
+        /// 
+        /// Setting this to true ensures that swagger config generation is tested to work in tandem with all controllers,
+        /// not just scoped to single controllers.
+        /// </summary>
+        public static bool ForceIncludeAllControllers = false;
+
+        public OwinStartup(params Type[] supportedControllers)
+        {
+            this.supportedControllers = supportedControllers;
+        }
+
+        public void Configuration(IAppBuilder app)
+        {
+            if (supportedControllers == null)
+                supportedControllers = new Type[] { };
+
+            var config = new HttpConfiguration();
+
+            config.Services.Replace(typeof(IHttpControllerSelector), new PredefinedHttpControllerSelector(config, supportedControllers, ForceIncludeAllControllers));
+
+            //Route Constraints
+            var constraintResolver = new DefaultInlineConstraintResolver();
+
+            config.MapHttpAttributeRoutes(constraintResolver);
+
+            config.Routes.MapHttpRoute(
+                name: "DefaultApi",
+                routeTemplate: "api/{controller}/{id}",
+                defaults: new { id = System.Web.Http.RouteParameter.Optional } // optional id
+                );
+
+            config.IncludeErrorDetailPolicy = IncludeErrorDetailPolicy.Always;
+
+            ConfigureFormatters(config);
+
+            config.EnsureInitialized();
+
+            EnableSwagger(config);
+
+            app.UseWebApi(config);
+        }
+
+        protected virtual void EnableSwagger(HttpConfiguration config)
+        {
+            config
+                .EnableSwagger(c => c.SingleApiVersion("v1", "A title for your API"))
+                .EnableSwaggerUi();
+        }
+
+        protected virtual void ConfigureFormatters(HttpConfiguration config)
+        {
+            // remove application/x-www-form-urlencoded formatters
+            var mediaTypeFormatters = config.Formatters.Where(y => y.SupportedMediaTypes.Any(c => c.MediaType == "application/x-www-form-urlencoded")).ToList();
+            mediaTypeFormatters.ForEach(x => config.Formatters.Remove(x));
+
+            //Xml Formatter
+            config.Formatters.Remove(config.Formatters.XmlFormatter);
+        }
+    }
+}

--- a/Swashbuckle.Tests/Owin/PredefinedHttpControllerSelector.cs
+++ b/Swashbuckle.Tests/Owin/PredefinedHttpControllerSelector.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web.Http;
+using System.Web.Http.Controllers;
+using System.Web.Http.Dispatcher;
+
+namespace Swashbuckle.Tests.Owin
+{
+    /// <summary>
+    /// Configures only selected controllers with Asp.Net.
+    /// Used in setting up owin in memory pipeline with routes only
+    /// from a predefined list of controllers
+    /// </summary>
+    public class PredefinedHttpControllerSelector : DefaultHttpControllerSelector
+    {
+        private readonly Type[] supportedControllers;
+
+        /// <summary>
+        /// Overrides supportedControllers param and adds all controllers to owin pipeline found in assembly.
+        /// Set this to true when running tests in CI, and use false when debugging/developing for faster feedback cycle.
+        /// </summary>
+        private readonly bool forceIncludeAllControllers;
+
+        public PredefinedHttpControllerSelector(HttpConfiguration configuration, Type[] supportedControllers, bool forceIncludeAllControllers) : base(configuration)
+        {
+            this.supportedControllers = supportedControllers;
+            this.forceIncludeAllControllers = forceIncludeAllControllers;
+        }
+
+        public override IDictionary<string, HttpControllerDescriptor> GetControllerMapping()
+        {
+            var m = base.GetControllerMapping();
+
+            if (forceIncludeAllControllers)
+                return m;
+
+            return m.Where(y => supportedControllers.Contains(y.Value.ControllerType))
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+        }
+    }
+}

--- a/Swashbuckle.Tests/Swashbuckle.Tests.csproj
+++ b/Swashbuckle.Tests/Swashbuckle.Tests.csproj
@@ -39,6 +39,18 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Hosting, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Hosting.3.0.1\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Testing, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Testing.3.0.1\lib\net45\Microsoft.Owin.Testing.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Moq">
       <HintPath>..\packages\Moq.4.0.10827\lib\NET40\Moq.dll</HintPath>
     </Reference>
@@ -49,24 +61,37 @@
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>
     </Reference>
+    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
+      <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.2\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Web.Http, Version=5.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.2\lib\net45\System.Web.Http.dll</HintPath>
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.Http.Owin, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Owin.5.2.3\lib\net45\System.Web.Http.Owin.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="HttpMessageHandlerTestBase.cs" />
+    <Compile Include="Owin\BaseInMemoryOwinSwaggerTest.cs" />
+    <Compile Include="Owin\InMemoryOwinTest.cs" />
+    <Compile Include="Owin\MultiSwaggerOwinStartup.cs" />
+    <Compile Include="Owin\OwinStartup.cs" />
+    <Compile Include="Owin\PredefinedHttpControllerSelector.cs" />
     <Compile Include="SwaggerUi\SwaggerUiTests.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/Swashbuckle.Tests/app.config
+++ b/Swashbuckle.Tests/app.config
@@ -8,11 +8,15 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.2.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.2.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Swashbuckle.Tests/packages.config
+++ b/Swashbuckle.Tests/packages.config
@@ -1,8 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.2" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.2" targetFramework="net45" />
-  <package id="Moq" version="4.0.10827" targetFramework="net40" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Owin" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.Owin" version="3.0.1" targetFramework="net45" />
+  <package id="Microsoft.Owin.Hosting" version="3.0.1" targetFramework="net45" />
+  <package id="Microsoft.Owin.Testing" version="3.0.1" targetFramework="net45" />
+  <package id="Moq" version="4.0.10827" targetFramework="net4" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
-  <package id="NUnit" version="2.6.2" targetFramework="net40" />
+  <package id="NUnit" version="2.6.2" targetFramework="net4" />
+  <package id="Owin" version="1.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This resolves #718 .

* The fix is just 2 lines: make http route config name unique, instead of using a constant (such as `swagger_docs`), it was made unique by adding route_template (`"swagger_docs" + routeTemplate)
* Added 2 tests - one tests that a default endpoint for swagger can be poked, the other adds an extra endpoint for swagger spec. The latter is what was failing.
* The tests are running a full in-memory owin pipeline, so we get to test `HttpConfigurationExtensions` and `SwaggerEnabledConfiguration`, which was previously completely uncovered. 
* To have in memory owin tests, a number of packages had to be brought into testing project. Let me know if this is an issue or not.
