### PR TITLE
Changes to readme for custom assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ The __InjectStylesheet__, __InjectJavaScript__ and __CustomAsset__ options all s
 1. Add a new file to your Web API project.
 2. In Solution Explorer, right click the file and open its properties window. Change the "Build Action" to "Embedded Resource".
 
-This will embed the file in your assembly and register it with a "Logical Name". This can then be passed to the relevant configuration method. It's based on the Project's default namespace, file location and file extension. For example, given a default namespace of "YourWebApiProject" and a file located at "/SwaggerExtensions/index.html", then the resource will be assigned the name - "YourWebApiProject.SwaggerExtensions.index.html". If you use "Swagger" as the root folder name for your custom assets, this will collide with the default route templates and the page willnot be loaded correctly.
+This will embed the file in your assembly and register it with a "Logical Name". This can then be passed to the relevant configuration method. It's based on the Project's default namespace, file location and file extension. For example, given a default namespace of "YourWebApiProject" and a file located at "/SwaggerExtensions/index.html", then the resource will be assigned the name - "YourWebApiProject.SwaggerExtensions.index.html". If you use "Swagger" as the root folder name for your custom assets, this will collide with the default route templates and the page will not be loaded correctly.
 
 ## Transitioning to Swashbuckle 5.0 ##
 

--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ Specify which HTTP operations will have the 'Try it out!' option. An empty param
 
 As an alternative, you can inject your own version of "index.html" and customize the markup and swagger-ui directly. Use the __CustomAsset__ option to instruct Swashbuckle to return your version instead of the default when a request is made for "index". As with all custom content, the file must be included in your project as an "Embedded Resource", and then the resource's "Logical Name" is passed to the method as shown below. See [Injecting Custom Content](#injecting-custom-content) for step by step instructions.
 
-For compatibility, you should base your custom "index.html" off [this version](https://github.com/domaindrivendev/Swashbuckle/blob/v5.2.1/Swashbuckle.Core/SwaggerUi/CustomAssets/index.html)
+For compatibility, you should base your custom "index.html" off [this version](https://github.com/domaindrivendev/Swashbuckle/blob/v5.3.2/Swashbuckle.Core/SwaggerUi/CustomAssets/index.html)
 
     httpConfiguration
         .EnableSwagger(c => c.SingleApiVersion("v1", "A title for your API"))
@@ -431,7 +431,7 @@ The __InjectStylesheet__, __InjectJavaScript__ and __CustomAsset__ options all s
 1. Add a new file to your Web API project.
 2. In Solution Explorer, right click the file and open its properties window. Change the "Build Action" to "Embedded Resource".
 
-This will embed the file in your assembly and register it with a "Logical Name". This can then be passed to the relevant configuration method. It's based on the Project's default namespace, file location and file extension. For example, given a default namespace of "YourWebApiProject" and a file located at "/SwaggerExtensions/index.html", then the resource will be assigned the name - "YourWebApiProject.SwaggerExtensions.index.html".
+This will embed the file in your assembly and register it with a "Logical Name". This can then be passed to the relevant configuration method. It's based on the Project's default namespace, file location and file extension. For example, given a default namespace of "YourWebApiProject" and a file located at "/SwaggerExtensions/index.html", then the resource will be assigned the name - "YourWebApiProject.SwaggerExtensions.index.html". If you use "Swagger" as the root folder name for your custom assets, this will collide with the default route templates and the page willnot be loaded correctly.
 
 ## Transitioning to Swashbuckle 5.0 ##
 


### PR DESCRIPTION
The 'base' file for custom index.html still linked to 5.2.1, this fails on jsoneditor. I put 5.3.2 instead.
From personal experience, discourage using 'swagger' as a folder name for custom assets.
