### PR TITLE
Bug 300: When an operationId has already been used; append a postfix...

### DIFF
--- a/Swashbuckle.Dummy.Core/Controllers/OverloadedAttributeRoutesController.cs
+++ b/Swashbuckle.Dummy.Core/Controllers/OverloadedAttributeRoutesController.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Web.Http;
+
+namespace Swashbuckle.Dummy.Controllers
+{
+    public class OverloadedAttributeRoutesController : ApiController
+    {
+        [Route("subscriptions/")]
+        public void GetAll()
+        {
+            throw new NotImplementedException();
+        }
+
+        [Route("users/")]
+        public void GetAll(int id)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Route("organisations/")]
+        public void GetAll(int id, string name)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Swashbuckle.Dummy.Core/Swashbuckle.Dummy.Core.csproj
+++ b/Swashbuckle.Dummy.Core/Swashbuckle.Dummy.Core.csproj
@@ -66,6 +66,7 @@
     <Compile Include="App_Start\CachingSwaggerProvider.cs" />
     <Compile Include="App_Start\CustomCorsPolicyProvider.cs" />
     <Compile Include="Controllers\MetadataAnnotatedTypesController.cs" />
+    <Compile Include="Controllers\OverloadedAttributeRoutesController.cs" />
     <Compile Include="Controllers\ConflictingTypesController.cs" />
     <Compile Include="Controllers\DataContractAnnotatedTypesController.cs" />
     <Compile Include="Controllers\FileDownloadController.cs" />

--- a/Swashbuckle.Tests/Swagger/CoreTests.cs
+++ b/Swashbuckle.Tests/Swagger/CoreTests.cs
@@ -543,6 +543,21 @@ namespace Swashbuckle.Tests.Swagger
         }
 
         [Test]
+        public void It_handles_overloaded_attribute_routes()
+        {
+            SetUpAttributeRoutesFrom(typeof(OverloadedAttributeRoutesController).Assembly);
+
+            var swagger = GetContent<JObject>("http://tempuri.org/swagger/docs/v1");
+            
+            var opIds = swagger["paths"]
+                .SelectMany(path => path)
+                .SelectMany(action => action)
+                .Select(action => action.First()["operationId"].ToString());
+            
+            Assert.AreEqual(opIds.Count(), opIds.GroupBy(x => x).Count());
+        }
+
+        [Test]
         public void It_handles_json_formatter_not_present()
         {
             SetUpDefaultRouteFor<ProductsController>();


### PR DESCRIPTION
…to get a unique one. This provides a resolution for issue #300 and at least ensures that a valid Swagger spec is produced.

Many thanks for your fantastic work on Swashbuckle; i've used it many times and would love to make a contribution - let me know if any further work is required!
