### PR TITLE
Optionally include extensions for primitives

### DIFF
--- a/Swashbuckle.Core/Application/SwaggerDocsConfig.cs
+++ b/Swashbuckle.Core/Application/SwaggerDocsConfig.cs
@@ -30,6 +30,7 @@ namespace Swashbuckle.Application
         private bool _ignoreObsoleteProperties;
         private bool _describeAllEnumsAsStrings;
         private bool _describeStringEnumsInCamelCase;
+        private bool _includeExtensionsForPrimitives;
         private readonly IList<Func<IOperationFilter>> _operationFilters;
         private readonly IList<Func<IDocumentFilter>> _documentFilters;
         private Func<IEnumerable<ApiDescription>, ApiDescription> _conflictingActionsResolver;
@@ -49,6 +50,7 @@ namespace Swashbuckle.Application
             _ignoreObsoleteProperties = false;
             _describeAllEnumsAsStrings = false;
             _describeStringEnumsInCamelCase = false;
+            _includeExtensionsForPrimitives = false;
             _operationFilters = new List<Func<IOperationFilter>>();
             _documentFilters = new List<Func<IDocumentFilter>>();
             _rootUrlResolver = DefaultRootUrlResolver;
@@ -178,6 +180,11 @@ namespace Swashbuckle.Application
             _ignoreObsoleteProperties = true;
         }
 
+        public void IncludeExtensionsForPrimitives()
+        {
+            _includeExtensionsForPrimitives = true;
+        }
+
         public void OperationFilter<TFilter>()
             where TFilter : IOperationFilter, new()
         {
@@ -243,6 +250,7 @@ namespace Swashbuckle.Application
                 schemaIdSelector: _schemaIdSelector,
                 describeAllEnumsAsStrings: _describeAllEnumsAsStrings,
                 describeStringEnumsInCamelCase: _describeStringEnumsInCamelCase,
+                includeExtensionsForPrimitives: _includeExtensionsForPrimitives,
                 operationFilters: _operationFilters.Select(factory => factory()),
                 documentFilters: _documentFilters.Select(factory => factory()),
                 conflictingActionsResolver: _conflictingActionsResolver

--- a/Swashbuckle.Core/Swagger/SchemaExtensions.cs
+++ b/Swashbuckle.Core/Swagger/SchemaExtensions.cs
@@ -51,6 +51,7 @@ namespace Swashbuckle.Swagger
 
             partialSchema.type = schema.type;
             partialSchema.format = schema.format;
+            partialSchema.vendorExtensions = schema.vendorExtensions;
 
             if (schema.items != null)
             {

--- a/Swashbuckle.Core/Swagger/SwaggerDocument.cs
+++ b/Swashbuckle.Core/Swagger/SwaggerDocument.cs
@@ -157,8 +157,6 @@ namespace Swashbuckle.Swagger
         public bool? required;
 
         public Schema schema;
-
-        public Dictionary<string, object> vendorExtensions = new Dictionary<string, object>();
     }
 
     public class Schema
@@ -262,6 +260,8 @@ namespace Swashbuckle.Swagger
         public IList<object> @enum;
 
         public int? multipleOf;
+
+        public Dictionary<string, object> vendorExtensions = new Dictionary<string, object>();
     }
 
     public class Response

--- a/Swashbuckle.Core/Swagger/SwaggerGenerator.cs
+++ b/Swashbuckle.Core/Swagger/SwaggerGenerator.cs
@@ -38,7 +38,8 @@ namespace Swashbuckle.Swagger
                 _options.IgnoreObsoleteProperties,
                 _options.SchemaIdSelector,
                 _options.DescribeAllEnumsAsStrings,
-                _options.DescribeStringEnumsInCamelCase);
+                _options.DescribeStringEnumsInCamelCase,
+                _options.IncludeExtensionsForPrimitives);
 
             Info info;
             _apiVersions.TryGetValue(apiVersion, out info);

--- a/Swashbuckle.Core/Swagger/SwaggerGeneratorOptions.cs
+++ b/Swashbuckle.Core/Swagger/SwaggerGeneratorOptions.cs
@@ -21,6 +21,7 @@ namespace Swashbuckle.Swagger
             Func<Type, string> schemaIdSelector = null, 
             bool describeAllEnumsAsStrings = false,
             bool describeStringEnumsInCamelCase = false,
+            bool includeExtensionsForPrimitives = false,
             IEnumerable<IOperationFilter> operationFilters = null,
             IEnumerable<IDocumentFilter> documentFilters = null,
             Func<IEnumerable<ApiDescription>, ApiDescription> conflictingActionsResolver = null
@@ -39,6 +40,7 @@ namespace Swashbuckle.Swagger
             SchemaIdSelector = schemaIdSelector ?? DefaultSchemaIdSelector;
             DescribeAllEnumsAsStrings = describeAllEnumsAsStrings;
             DescribeStringEnumsInCamelCase = describeStringEnumsInCamelCase;
+            IncludeExtensionsForPrimitives = includeExtensionsForPrimitives;
             OperationFilters = operationFilters ?? new List<IOperationFilter>();
             DocumentFilters = documentFilters ?? new List<IDocumentFilter>();
             ConflictingActionsResolver = conflictingActionsResolver ?? DefaultConflictingActionsResolver;
@@ -69,6 +71,8 @@ namespace Swashbuckle.Swagger
         public bool DescribeAllEnumsAsStrings { get; private set; }
 
         public bool DescribeStringEnumsInCamelCase { get; private set; }
+
+        public bool IncludeExtensionsForPrimitives { get; private set; }
 
         public IEnumerable<IOperationFilter> OperationFilters { get; private set; }
 

--- a/Swashbuckle.Dummy.Core/Controllers/PrimitiveArrayTypesController.cs
+++ b/Swashbuckle.Dummy.Core/Controllers/PrimitiveArrayTypesController.cs
@@ -1,0 +1,199 @@
+﻿using System;
+using System.Web.Http;
+using Swashbuckle.Dummy.Types;
+
+namespace Swashbuckle.Dummy.Controllers
+{
+    public class PrimitiveArrayTypesController : ApiController
+    {
+        public bool[] EchoBoolean(bool[] value)
+        {
+            return value;
+        }
+
+        public byte[] EchoByte(byte[] value)
+        {
+            return value;
+        }
+
+        public sbyte[] EchoSByte(sbyte[] value)
+        {
+            return value;
+        }
+
+        public short[] EchoInt16(short[] value)
+        {
+            return value;
+        }
+
+        public ushort[] EchoUInt16(ushort[] value)
+        {
+            return value;
+        }
+
+        public int[] EchoInt32(int[] value)
+        {
+            return value;
+        }
+
+        public uint[] EchoUInt32(uint[] value)
+        {
+            return value;
+        }
+
+        public long[] EchoInt64(long[] value)
+        {
+            return value;
+        }
+
+        public ulong[] EchoUInt64(ulong[] value)
+        {
+            return value;
+        }
+
+        public float[] EchoSingle(float[] value)
+        {
+            return value;
+        }
+
+        public double[] EchoDouble(double[] value)
+        {
+            return value;
+        }
+
+        public decimal[] EchoDecimal(decimal[] value)
+        {
+            return value;
+        }
+
+        public DateTime[] EchoDateTime(DateTime[] value)
+        {
+            return value;
+        }
+
+        public DateTimeOffset[] EchoDateTimeOffset(DateTimeOffset[] value)
+        {
+            return value;
+        }
+
+        public TimeSpan[] EchoTimeSpan(TimeSpan[] value)
+        {
+            return value;
+        }
+
+        public Guid[] EchoGuid(Guid[] value)
+        {
+            return value;
+        }
+
+        public PrimitiveEnum[] EchoEnum(PrimitiveEnum[] value)
+        {
+            return value;
+        }
+
+        public char[] EchoChar(char[] value)
+        {
+            return value;
+        }
+
+        public bool?[] EchoNullableBoolean(bool?[] value)
+        {
+            return value;
+        }
+
+        public byte?[] EchoNullableByte(byte?[] value)
+        {
+            return value;
+        }
+
+        public sbyte?[] EchoNullableSByte(sbyte?[] value)
+        {
+            return value;
+        }
+
+        public short?[] EchoNullableInt16(short?[] value)
+        {
+            return value;
+        }
+
+        public ushort?[] EchoNullableUInt16(ushort?[] value)
+        {
+            return value;
+        }
+
+        public int?[] EchoNullableInt32(int?[] value)
+        {
+            return value;
+        }
+
+        public uint?[] EchoNullableUInt32(uint?[] value)
+        {
+            return value;
+        }
+
+        public long?[] EchoNullableInt64(long?[] value)
+        {
+            return value;
+        }
+
+        public ulong?[] EchoNullableUInt64(ulong?[] value)
+        {
+            return value;
+        }
+
+        public float?[] EchoNullableSingle(float?[] value)
+        {
+            return value;
+        }
+
+        public double?[] EchoNullableDouble(double?[] value)
+        {
+            return value;
+        }
+
+        public decimal?[] EchoNullableDecimal(decimal?[] value)
+        {
+            return value;
+        }
+
+        public DateTime?[] EchoNullableDateTime(DateTime?[] value)
+        {
+            return value;
+        }
+
+        public DateTimeOffset?[] EchoNullableDateTimeOffset(DateTimeOffset?[] value)
+        {
+            return value;
+        }
+
+        public TimeSpan?[] EchoNullableTimeSpan(TimeSpan?[] value)
+        {
+            return value;
+        }
+
+        public Guid?[] EchoNullableGuid(Guid?[] value)
+        {
+            return value;
+        }
+
+        public PrimitiveEnum?[] EchoNullableEnum(PrimitiveEnum?[] value)
+        {
+            return value;
+        }
+
+        public char?[] EchoNullableChar(char?[] value)
+        {
+            return value;
+        }
+
+        public string[] EchoString(string[] value)
+        {
+            return value;
+        }
+
+        public PrimitiveArrayComposite EchoComposite(PrimitiveArrayComposite value)
+        {
+            return value;
+        }
+    }
+}

--- a/Swashbuckle.Dummy.Core/Controllers/PrimitiveTypesController.cs
+++ b/Swashbuckle.Dummy.Core/Controllers/PrimitiveTypesController.cs
@@ -1,0 +1,199 @@
+﻿using System;
+using System.Web.Http;
+using Swashbuckle.Dummy.Types;
+
+namespace Swashbuckle.Dummy.Controllers
+{
+    public class PrimitiveTypesController : ApiController
+    {
+        public bool EchoBoolean(bool value)
+        {
+            return value;
+        }
+
+        public byte EchoByte(byte value)
+        {
+            return value;
+        }
+
+        public sbyte EchoSByte(sbyte value)
+        {
+            return value;
+        }
+
+        public short EchoInt16(short value)
+        {
+            return value;
+        }
+
+        public ushort EchoUInt16(ushort value)
+        {
+            return value;
+        }
+
+        public int EchoInt32(int value)
+        {
+            return value;
+        }
+
+        public uint EchoUInt32(uint value)
+        {
+            return value;
+        }
+
+        public long EchoInt64(long value)
+        {
+            return value;
+        }
+
+        public ulong EchoUInt64(ulong value)
+        {
+            return value;
+        }
+
+        public float EchoSingle(float value)
+        {
+            return value;
+        }
+
+        public double EchoDouble(double value)
+        {
+            return value;
+        }
+
+        public decimal EchoDecimal(decimal value)
+        {
+            return value;
+        }
+
+        public DateTime EchoDateTime(DateTime value)
+        {
+            return value;
+        }
+
+        public DateTimeOffset EchoDateTimeOffset(DateTimeOffset value)
+        {
+            return value;
+        }
+
+        public TimeSpan EchoTimeSpan(TimeSpan value)
+        {
+            return value;
+        }
+
+        public Guid EchoGuid(Guid value)
+        {
+            return value;
+        }
+
+        public PrimitiveEnum EchoEnum(PrimitiveEnum value)
+        {
+            return value;
+        }
+
+        public char EchoChar(char value)
+        {
+            return value;
+        }
+
+        public bool? EchoNullableBoolean(bool? value)
+        {
+            return value;
+        }
+
+        public byte? EchoNullableByte(byte? value)
+        {
+            return value;
+        }
+
+        public sbyte? EchoNullableSByte(sbyte? value)
+        {
+            return value;
+        }
+
+        public short? EchoNullableInt16(short? value)
+        {
+            return value;
+        }
+
+        public ushort? EchoNullableUInt16(ushort? value)
+        {
+            return value;
+        }
+
+        public int? EchoNullableInt32(int? value)
+        {
+            return value;
+        }
+
+        public uint? EchoNullableUInt32(uint? value)
+        {
+            return value;
+        }
+
+        public long? EchoNullableInt64(long? value)
+        {
+            return value;
+        }
+
+        public ulong? EchoNullableUInt64(ulong? value)
+        {
+            return value;
+        }
+
+        public float? EchoNullableSingle(float? value)
+        {
+            return value;
+        }
+
+        public double? EchoNullableDouble(double? value)
+        {
+            return value;
+        }
+
+        public decimal? EchoNullableDecimal(decimal? value)
+        {
+            return value;
+        }
+
+        public DateTime? EchoNullableDateTime(DateTime? value)
+        {
+            return value;
+        }
+
+        public DateTimeOffset? EchoNullableDateTimeOffset(DateTimeOffset? value)
+        {
+            return value;
+        }
+
+        public TimeSpan? EchoNullableTimeSpan(TimeSpan? value)
+        {
+            return value;
+        }
+
+        public Guid? EchoNullableGuid(Guid? value)
+        {
+            return value;
+        }
+
+        public PrimitiveEnum? EchoNullableEnum(PrimitiveEnum? value)
+        {
+            return value;
+        }
+
+        public char? EchoNullableChar(char? value)
+        {
+            return value;
+        }
+
+        public string EchoString(string value)
+        {
+            return value;
+        }
+
+        public PrimitiveComposite EchoComposite(PrimitiveComposite value)
+        {
+            return value;
+        }
+    }
+}

--- a/Swashbuckle.Dummy.Core/Swashbuckle.Dummy.Core.csproj
+++ b/Swashbuckle.Dummy.Core/Swashbuckle.Dummy.Core.csproj
@@ -77,6 +77,8 @@
     <Compile Include="Controllers\NullableTypesController.cs" />
     <Compile Include="Controllers\ObsoletePropertiesController.cs" />
     <Compile Include="Controllers\PathRequiredController.cs" />
+    <Compile Include="Controllers\PrimitiveArrayTypesController.cs" />
+    <Compile Include="Controllers\PrimitiveTypesController.cs" />
     <Compile Include="Controllers\ProtectedResourcesController.cs" />
     <Compile Include="Controllers\SelfReferencingTypesController.cs" />
     <Compile Include="Controllers\CustomersController.cs" />
@@ -105,6 +107,9 @@
     <Compile Include="SwaggerExtensions\AddGetMessageExamples.cs" />
     <Compile Include="SwaggerExtensions\SupportFlaggedEnums.cs" />
     <Compile Include="SwaggerExtensions\UpdateFileDownloadOperations.cs" />
+    <Compile Include="Types\PrimitiveArrayComposite.cs" />
+    <Compile Include="Types\PrimitiveComposite.cs" />
+    <Compile Include="Types\PrimitiveEnum.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="App_Start\SwaggerConfig.cs" />

--- a/Swashbuckle.Dummy.Core/Types/PrimitiveArrayComposite.cs
+++ b/Swashbuckle.Dummy.Core/Types/PrimitiveArrayComposite.cs
@@ -1,0 +1,46 @@
+﻿using System;
+
+namespace Swashbuckle.Dummy.Types
+{
+    public class PrimitiveArrayComposite
+    {
+        public bool[] Boolean { get; set; }
+        public byte[] Byte { get; set; }
+        public sbyte[] SByte { get; set; }
+        public short[] Int16 { get; set; }
+        public ushort[] UInt16 { get; set; }
+        public int[] Int32 { get; set; }
+        public uint[] UInt32 { get; set; }
+        public long[] Int64 { get; set; }
+        public ulong[] UInt64 { get; set; }
+        public float[] Single { get; set; }
+        public double[] Double { get; set; }
+        public decimal[] Decimal { get; set; }
+        public DateTime[] DateTime { get; set; }
+        public DateTimeOffset[] DateTimeOffset { get; set; }
+        public TimeSpan[] TimeSpan { get; set; }
+        public Guid[] Guid { get; set; }
+        public PrimitiveEnum[] Enum { get; set; }
+        public char[] Char { get; set; }
+
+        public bool?[] NullableBoolean { get; set; }
+        public byte?[] NullableByte { get; set; }
+        public sbyte?[] NullableSByte { get; set; }
+        public short?[] NullableInt16 { get; set; }
+        public ushort?[] NullableUInt16 { get; set; }
+        public int?[] NullableInt32 { get; set; }
+        public uint?[] NullableUInt32 { get; set; }
+        public long?[] NullableInt64 { get; set; }
+        public ulong?[] NullableUInt64 { get; set; }
+        public float?[] NullableSingle { get; set; }
+        public double?[] NullableDouble { get; set; }
+        public decimal?[] NullableDecimal { get; set; }
+        public DateTime?[] NullableDateTime { get; set; }
+        public DateTimeOffset?[] NullableDateTimeOffset { get; set; }
+        public TimeSpan?[] NullableTimeSpan { get; set; }
+        public Guid?[] NullableGuid { get; set; }
+        public PrimitiveEnum?[] NullableEnum { get; set; }
+        public char?[] NullableChar { get; set; }
+        public string[] String { get; set; }
+    }
+}

--- a/Swashbuckle.Dummy.Core/Types/PrimitiveComposite.cs
+++ b/Swashbuckle.Dummy.Core/Types/PrimitiveComposite.cs
@@ -1,0 +1,46 @@
+﻿using System;
+
+namespace Swashbuckle.Dummy.Types
+{
+    public class PrimitiveComposite
+    {
+        public bool Boolean { get; set; }
+        public byte Byte { get; set; }
+        public sbyte SByte { get; set; }
+        public short Int16 { get; set; }
+        public ushort UInt16 { get; set; }
+        public int Int32 { get; set; }
+        public uint UInt32 { get; set; }
+        public long Int64 { get; set; }
+        public ulong UInt64 { get; set; }
+        public float Single { get; set; }
+        public double Double { get; set; }
+        public decimal Decimal { get; set; }
+        public DateTime DateTime { get; set; }
+        public DateTimeOffset DateTimeOffset { get; set; }
+        public TimeSpan TimeSpan { get; set; }
+        public Guid Guid { get; set; }
+        public PrimitiveEnum Enum { get; set; }
+        public char Char { get; set; }
+
+        public bool? NullableBoolean { get; set; }
+        public byte? NullableByte { get; set; }
+        public sbyte? NullableSByte { get; set; }
+        public short? NullableInt16 { get; set; }
+        public ushort? NullableUInt16 { get; set; }
+        public int? NullableInt32 { get; set; }
+        public uint? NullableUInt32 { get; set; }
+        public long? NullableInt64 { get; set; }
+        public ulong? NullableUInt64 { get; set; }
+        public float? NullableSingle { get; set; }
+        public double? NullableDouble { get; set; }
+        public decimal? NullableDecimal { get; set; }
+        public DateTime? NullableDateTime { get; set; }
+        public DateTimeOffset? NullableDateTimeOffset { get; set; }
+        public TimeSpan? NullableTimeSpan { get; set; }
+        public Guid? NullableGuid { get; set; }
+        public PrimitiveEnum? NullableEnum { get; set; }
+        public char? NullableChar { get; set; }
+        public string String { get; set; }
+    }
+}

--- a/Swashbuckle.Dummy.Core/Types/PrimitiveEnum.cs
+++ b/Swashbuckle.Dummy.Core/Types/PrimitiveEnum.cs
@@ -1,0 +1,7 @@
+﻿namespace Swashbuckle.Dummy.Types
+{
+    public enum PrimitiveEnum
+    {
+        OneFish, TwoFish, RedFish, BlueFish
+    }
+}


### PR DESCRIPTION
Following up from [Ahoy PR #65](https://github.com/domaindrivendev/Ahoy/pull/65).

Capture original primitive type names and whether or not they are nullable. This enables much more fidelity for code generators to access and can be used first and foremost to determine when common primitive types should be nullable or not. (See [OpenAPI-Specification issue #229](https://github.com/OAI/OpenAPI-Specification/issues/229) for related discussions - consensus seems to be to use an `x-nullable` extension for now.)

Secondly, this PR also allows the possibility to preserve C# types end-to-end; variations in common types are currently reduced to lowest common denominator types like `integer` and `number` etc. Given the C# domain of Swashbuckle - this is my default scenario and I wouldn't be surprised if it was the case for many others - I would also like C# type fidelity to be preserved where possible, so generated C# client proxies use the same types as the C# server.

Note that these changes are _optional_ opt-in, and only enabled by configuring Swashbuckle accordingly; but if these changes are accepted then we can go on to modify code generators to recognize these extensions and get the final C# end-to-end piece in place. (I'm currently invested in pursuing this for [AutoRest](https://github.com/Azure/autorest).)