### PR TITLE
Apply schema filters everywhere

### DIFF
--- a/Swashbuckle.Core/Application/SwaggerDocsConfig.cs
+++ b/Swashbuckle.Core/Application/SwaggerDocsConfig.cs
@@ -30,6 +30,7 @@ namespace Swashbuckle.Application
         private bool _ignoreObsoleteProperties;
         private bool _describeAllEnumsAsStrings;
         private bool _describeStringEnumsInCamelCase;
+        private bool _applyFiltersToAllSchemas;
         private readonly IList<Func<IOperationFilter>> _operationFilters;
         private readonly IList<Func<IDocumentFilter>> _documentFilters;
         private Func<IEnumerable<ApiDescription>, ApiDescription> _conflictingActionsResolver;
@@ -49,6 +50,7 @@ namespace Swashbuckle.Application
             _ignoreObsoleteProperties = false;
             _describeAllEnumsAsStrings = false;
             _describeStringEnumsInCamelCase = false;
+            _applyFiltersToAllSchemas = false;
             _operationFilters = new List<Func<IOperationFilter>>();
             _documentFilters = new List<Func<IDocumentFilter>>();
             _rootUrlResolver = DefaultRootUrlResolver;
@@ -178,6 +180,12 @@ namespace Swashbuckle.Application
             _ignoreObsoleteProperties = true;
         }
 
+        [Obsolete("This will be removed in 6.0.0; it will always be true.")]
+        public void ApplyFiltersToAllSchemas()
+        {
+            _applyFiltersToAllSchemas = true;
+        }
+
         public void OperationFilter<TFilter>()
             where TFilter : IOperationFilter, new()
         {
@@ -243,6 +251,7 @@ namespace Swashbuckle.Application
                 schemaIdSelector: _schemaIdSelector,
                 describeAllEnumsAsStrings: _describeAllEnumsAsStrings,
                 describeStringEnumsInCamelCase: _describeStringEnumsInCamelCase,
+                applyFiltersToAllSchemas: _applyFiltersToAllSchemas,
                 operationFilters: _operationFilters.Select(factory => factory()),
                 documentFilters: _documentFilters.Select(factory => factory()),
                 conflictingActionsResolver: _conflictingActionsResolver

--- a/Swashbuckle.Core/Swagger/SchemaExtensions.cs
+++ b/Swashbuckle.Core/Swagger/SchemaExtensions.cs
@@ -51,6 +51,7 @@ namespace Swashbuckle.Swagger
 
             partialSchema.type = schema.type;
             partialSchema.format = schema.format;
+            partialSchema.vendorExtensions = schema.vendorExtensions;
 
             if (schema.items != null)
             {

--- a/Swashbuckle.Core/Swagger/SchemaRegistry.cs
+++ b/Swashbuckle.Core/Swagger/SchemaRegistry.cs
@@ -81,32 +81,32 @@ namespace Swashbuckle.Swagger
 
         private Schema CreateInlineSchema(Type type)
         {
-            if (_customSchemaMappings.ContainsKey(type))
-                return _customSchemaMappings[type]();
-
             var jsonContract = _contractResolver.ResolveContract(type);
 
+            if (_customSchemaMappings.ContainsKey(type))
+                return FilterSchema(_customSchemaMappings[type](), jsonContract);
+
             if (jsonContract is JsonPrimitiveContract)
-                return CreatePrimitiveSchema((JsonPrimitiveContract)jsonContract);
+                return FilterSchema(CreatePrimitiveSchema((JsonPrimitiveContract)jsonContract), jsonContract);
 
             var dictionaryContract = jsonContract as JsonDictionaryContract;
             if (dictionaryContract != null)
                 return dictionaryContract.IsSelfReferencing()
                     ? CreateRefSchema(type)
-                    : CreateDictionarySchema(dictionaryContract);
+                    : FilterSchema(CreateDictionarySchema(dictionaryContract), jsonContract);
 
             var arrayContract = jsonContract as JsonArrayContract;
             if (arrayContract != null)
                 return arrayContract.IsSelfReferencing()
                     ? CreateRefSchema(type)
-                    : CreateArraySchema(arrayContract);
+                    : FilterSchema(CreateArraySchema(arrayContract), jsonContract);
 
             var objectContract = jsonContract as JsonObjectContract;
             if (objectContract != null && !objectContract.IsAmbiguous())
                 return CreateRefSchema(type);
 
             // Fallback to abstract "object"
-            return new Schema { type = "object" };
+            return FilterSchema(new Schema { type = "object" }, jsonContract);
         }
 
         private Schema CreateDefinitionSchema(Type type)
@@ -114,13 +114,13 @@ namespace Swashbuckle.Swagger
             var jsonContract = _contractResolver.ResolveContract(type);
 
             if (jsonContract is JsonDictionaryContract)
-                return CreateDictionarySchema((JsonDictionaryContract)jsonContract);
+                return FilterSchema(CreateDictionarySchema((JsonDictionaryContract)jsonContract), jsonContract);
 
             if (jsonContract is JsonArrayContract)
-                return CreateArraySchema((JsonArrayContract)jsonContract);
+                return FilterSchema(CreateArraySchema((JsonArrayContract)jsonContract), jsonContract);
 
             if (jsonContract is JsonObjectContract)
-                return CreateObjectSchema((JsonObjectContract)jsonContract);
+                return FilterSchema(CreateObjectSchema((JsonObjectContract)jsonContract), jsonContract);
 
             throw new InvalidOperationException(
                 String.Format("Unsupported type - {0} for Defintitions. Must be Dictionary, Array or Object", type));
@@ -135,6 +135,8 @@ namespace Swashbuckle.Swagger
 
             switch (type.FullName)
             {
+                case "System.Boolean":
+                    return new Schema { type = "boolean" };
                 case "System.Byte":
                 case "System.SByte":
                 case "System.Int16":
@@ -151,10 +153,7 @@ namespace Swashbuckle.Swagger
                 case "System.Decimal":
                     return new Schema { type = "number", format = "double" };
                 case "System.Byte[]":
-                case "System.SByte[]":
                     return new Schema { type = "string", format = "byte" };
-                case "System.Boolean":
-                    return new Schema { type = "boolean" };
                 case "System.DateTime":
                 case "System.DateTimeOffset":
                     return new Schema { type = "string", format = "date-time" };
@@ -222,10 +221,10 @@ namespace Swashbuckle.Swagger
         {
             var itemType = arrayContract.CollectionItemType ?? typeof(object);
             return new Schema
-                {
-                    type = "array",
-                    items = CreateInlineSchema(itemType)
-                };
+            {
+                type = "array",
+                items = CreateInlineSchema(itemType)
+            };
         }
 
         private Schema CreateObjectSchema(JsonObjectContract jsonContract)
@@ -242,26 +241,12 @@ namespace Swashbuckle.Swagger
                 .Select(propInfo => propInfo.PropertyName)
                 .ToList();
 
-            var schema = new Schema
+            return new Schema
             {
                 required = required.Any() ? required : null, // required can be null but not empty
                 properties = properties,
                 type = "object"
             };
-
-            // NOTE: In next major version, _modelFilters will completely replace _schemaFilters
-            var modelFilterContext = new ModelFilterContext(jsonContract.UnderlyingType, jsonContract, this);
-            foreach (var filter in _modelFilters)
-            {
-                filter.Apply(schema, modelFilterContext);
-            }
-
-            foreach (var filter in _schemaFilters)
-            {
-                filter.Apply(schema, this, jsonContract.UnderlyingType);
-            }
-
-            return schema;
         }
 
         private Schema CreateRefSchema(Type type)
@@ -282,6 +267,27 @@ namespace Swashbuckle.Swagger
             }
 
             return new Schema { @ref = "#/definitions/" + _referencedTypes[type].SchemaId };
+        }
+
+        private Schema FilterSchema(Schema schema, JsonContract jsonContract)
+        {
+            var jsonObjectContract = jsonContract as JsonObjectContract;
+            if (jsonObjectContract != null)
+            {
+                // NOTE: In next major version, _modelFilters will completely replace _schemaFilters
+                var modelFilterContext = new ModelFilterContext(jsonObjectContract.UnderlyingType, jsonObjectContract, this);
+                foreach (var filter in _modelFilters)
+                {
+                    filter.Apply(schema, modelFilterContext);
+                }
+            }
+
+            foreach (var filter in _schemaFilters)
+            {
+                filter.Apply(schema, this, jsonContract.UnderlyingType);
+            }
+
+            return schema;
         }
     }
 }

--- a/Swashbuckle.Core/Swagger/SwaggerDocument.cs
+++ b/Swashbuckle.Core/Swagger/SwaggerDocument.cs
@@ -157,8 +157,6 @@ namespace Swashbuckle.Swagger
         public bool? required;
 
         public Schema schema;
-
-        public Dictionary<string, object> vendorExtensions = new Dictionary<string, object>();
     }
 
     public class Schema
@@ -262,6 +260,8 @@ namespace Swashbuckle.Swagger
         public IList<object> @enum;
 
         public int? multipleOf;
+
+        public Dictionary<string, object> vendorExtensions = new Dictionary<string, object>();
     }
 
     public class Response

--- a/Swashbuckle.Core/Swagger/SwaggerGenerator.cs
+++ b/Swashbuckle.Core/Swagger/SwaggerGenerator.cs
@@ -38,7 +38,8 @@ namespace Swashbuckle.Swagger
                 _options.IgnoreObsoleteProperties,
                 _options.SchemaIdSelector,
                 _options.DescribeAllEnumsAsStrings,
-                _options.DescribeStringEnumsInCamelCase);
+                _options.DescribeStringEnumsInCamelCase,
+                _options.ApplyFiltersToAllSchemas);
 
             Info info;
             _apiVersions.TryGetValue(apiVersion, out info);

--- a/Swashbuckle.Core/Swagger/SwaggerGeneratorOptions.cs
+++ b/Swashbuckle.Core/Swagger/SwaggerGeneratorOptions.cs
@@ -21,6 +21,7 @@ namespace Swashbuckle.Swagger
             Func<Type, string> schemaIdSelector = null, 
             bool describeAllEnumsAsStrings = false,
             bool describeStringEnumsInCamelCase = false,
+            bool applyFiltersToAllSchemas = false,
             IEnumerable<IOperationFilter> operationFilters = null,
             IEnumerable<IDocumentFilter> documentFilters = null,
             Func<IEnumerable<ApiDescription>, ApiDescription> conflictingActionsResolver = null
@@ -39,6 +40,7 @@ namespace Swashbuckle.Swagger
             SchemaIdSelector = schemaIdSelector ?? DefaultSchemaIdSelector;
             DescribeAllEnumsAsStrings = describeAllEnumsAsStrings;
             DescribeStringEnumsInCamelCase = describeStringEnumsInCamelCase;
+            ApplyFiltersToAllSchemas = applyFiltersToAllSchemas;
             OperationFilters = operationFilters ?? new List<IOperationFilter>();
             DocumentFilters = documentFilters ?? new List<IDocumentFilter>();
             ConflictingActionsResolver = conflictingActionsResolver ?? DefaultConflictingActionsResolver;
@@ -69,6 +71,8 @@ namespace Swashbuckle.Swagger
         public bool DescribeAllEnumsAsStrings { get; private set; }
 
         public bool DescribeStringEnumsInCamelCase { get; private set; }
+
+        public bool ApplyFiltersToAllSchemas { get; private set; }
 
         public IEnumerable<IOperationFilter> OperationFilters { get; private set; }
 

--- a/Swashbuckle.Core/Swagger/XmlComments/ApplyXmlTypeComments.cs
+++ b/Swashbuckle.Core/Swagger/XmlComments/ApplyXmlTypeComments.cs
@@ -33,12 +33,15 @@ namespace Swashbuckle.Swagger.XmlComments
                     model.description = summaryNode.ExtractContent();
             }
 
-            foreach (var entry in model.properties)
+            if (model.properties != null)
             {
-                var jsonProperty = context.JsonObjectContract.Properties[entry.Key];
-                if (jsonProperty == null) continue;
+                foreach (var entry in model.properties)
+                {
+                    var jsonProperty = context.JsonObjectContract.Properties[entry.Key];
+                    if (jsonProperty == null) continue;
 
-                ApplyPropertyComments(entry.Value, jsonProperty.PropertyInfo());
+                    ApplyPropertyComments(entry.Value, jsonProperty.PropertyInfo());
+                }
             }
         }
 

--- a/Swashbuckle.Dummy.Core/Controllers/PrimitiveArrayTypesController.cs
+++ b/Swashbuckle.Dummy.Core/Controllers/PrimitiveArrayTypesController.cs
@@ -1,0 +1,194 @@
+﻿using System;
+using System.Web.Http;
+using Swashbuckle.Dummy.Types;
+
+namespace Swashbuckle.Dummy.Controllers
+{
+    public class PrimitiveArrayTypesController : ApiController
+    {
+        public bool[] EchoBoolean(bool[] value)
+        {
+            return value;
+        }
+
+        public byte[] EchoByte(byte[] value)
+        {
+            return value;
+        }
+
+        public sbyte[] EchoSByte(sbyte[] value)
+        {
+            return value;
+        }
+
+        public short[] EchoInt16(short[] value)
+        {
+            return value;
+        }
+
+        public ushort[] EchoUInt16(ushort[] value)
+        {
+            return value;
+        }
+
+        public int[] EchoInt32(int[] value)
+        {
+            return value;
+        }
+
+        public uint[] EchoUInt32(uint[] value)
+        {
+            return value;
+        }
+
+        public long[] EchoInt64(long[] value)
+        {
+            return value;
+        }
+
+        public ulong[] EchoUInt64(ulong[] value)
+        {
+            return value;
+        }
+
+        public float[] EchoSingle(float[] value)
+        {
+            return value;
+        }
+
+        public double[] EchoDouble(double[] value)
+        {
+            return value;
+        }
+
+        public decimal[] EchoDecimal(decimal[] value)
+        {
+            return value;
+        }
+
+        public DateTime[] EchoDateTime(DateTime[] value)
+        {
+            return value;
+        }
+
+        public DateTimeOffset[] EchoDateTimeOffset(DateTimeOffset[] value)
+        {
+            return value;
+        }
+
+        public TimeSpan[] EchoTimeSpan(TimeSpan[] value)
+        {
+            return value;
+        }
+
+        public Guid[] EchoGuid(Guid[] value)
+        {
+            return value;
+        }
+
+        public PrimitiveEnum[] EchoEnum(PrimitiveEnum[] value)
+        {
+            return value;
+        }
+
+        public char[] EchoChar(char[] value)
+        {
+            return value;
+        }
+
+        public bool?[] EchoNullableBoolean(bool?[] value)
+        {
+            return value;
+        }
+
+        public byte?[] EchoNullableByte(byte?[] value)
+        {
+            return value;
+        }
+
+        public sbyte?[] EchoNullableSByte(sbyte?[] value)
+        {
+            return value;
+        }
+
+        public short?[] EchoNullableInt16(short?[] value)
+        {
+            return value;
+        }
+
+        public ushort?[] EchoNullableUInt16(ushort?[] value)
+        {
+            return value;
+        }
+
+        public int?[] EchoNullableInt32(int?[] value)
+        {
+            return value;
+        }
+
+        public uint?[] EchoNullableUInt32(uint?[] value)
+        {
+            return value;
+        }
+
+        public long?[] EchoNullableInt64(long?[] value)
+        {
+            return value;
+        }
+
+        public ulong?[] EchoNullableUInt64(ulong?[] value)
+        {
+            return value;
+        }
+
+        public float?[] EchoNullableSingle(float?[] value)
+        {
+            return value;
+        }
+
+        public double?[] EchoNullableDouble(double?[] value)
+        {
+            return value;
+        }
+
+        public decimal?[] EchoNullableDecimal(decimal?[] value)
+        {
+            return value;
+        }
+
+        public DateTime?[] EchoNullableDateTime(DateTime?[] value)
+        {
+            return value;
+        }
+
+        public DateTimeOffset?[] EchoNullableDateTimeOffset(DateTimeOffset?[] value)
+        {
+            return value;
+        }
+
+        public TimeSpan?[] EchoNullableTimeSpan(TimeSpan?[] value)
+        {
+            return value;
+        }
+
+        public Guid?[] EchoNullableGuid(Guid?[] value)
+        {
+            return value;
+        }
+
+        public PrimitiveEnum?[] EchoNullableEnum(PrimitiveEnum?[] value)
+        {
+            return value;
+        }
+
+        public char?[] EchoNullableChar(char?[] value)
+        {
+            return value;
+        }
+
+        public string[] EchoString(string[] value)
+        {
+            return value;
+        }
+    }
+}

--- a/Swashbuckle.Dummy.Core/Controllers/PrimitiveTypesController.cs
+++ b/Swashbuckle.Dummy.Core/Controllers/PrimitiveTypesController.cs
@@ -1,0 +1,194 @@
+﻿using System;
+using System.Web.Http;
+using Swashbuckle.Dummy.Types;
+
+namespace Swashbuckle.Dummy.Controllers
+{
+    public class PrimitiveTypesController : ApiController
+    {
+        public bool EchoBoolean(bool value)
+        {
+            return value;
+        }
+
+        public byte EchoByte(byte value)
+        {
+            return value;
+        }
+
+        public sbyte EchoSByte(sbyte value)
+        {
+            return value;
+        }
+
+        public short EchoInt16(short value)
+        {
+            return value;
+        }
+
+        public ushort EchoUInt16(ushort value)
+        {
+            return value;
+        }
+
+        public int EchoInt32(int value)
+        {
+            return value;
+        }
+
+        public uint EchoUInt32(uint value)
+        {
+            return value;
+        }
+
+        public long EchoInt64(long value)
+        {
+            return value;
+        }
+
+        public ulong EchoUInt64(ulong value)
+        {
+            return value;
+        }
+
+        public float EchoSingle(float value)
+        {
+            return value;
+        }
+
+        public double EchoDouble(double value)
+        {
+            return value;
+        }
+
+        public decimal EchoDecimal(decimal value)
+        {
+            return value;
+        }
+
+        public DateTime EchoDateTime(DateTime value)
+        {
+            return value;
+        }
+
+        public DateTimeOffset EchoDateTimeOffset(DateTimeOffset value)
+        {
+            return value;
+        }
+
+        public TimeSpan EchoTimeSpan(TimeSpan value)
+        {
+            return value;
+        }
+
+        public Guid EchoGuid(Guid value)
+        {
+            return value;
+        }
+
+        public PrimitiveEnum EchoEnum(PrimitiveEnum value)
+        {
+            return value;
+        }
+
+        public char EchoChar(char value)
+        {
+            return value;
+        }
+
+        public bool? EchoNullableBoolean(bool? value)
+        {
+            return value;
+        }
+
+        public byte? EchoNullableByte(byte? value)
+        {
+            return value;
+        }
+
+        public sbyte? EchoNullableSByte(sbyte? value)
+        {
+            return value;
+        }
+
+        public short? EchoNullableInt16(short? value)
+        {
+            return value;
+        }
+
+        public ushort? EchoNullableUInt16(ushort? value)
+        {
+            return value;
+        }
+
+        public int? EchoNullableInt32(int? value)
+        {
+            return value;
+        }
+
+        public uint? EchoNullableUInt32(uint? value)
+        {
+            return value;
+        }
+
+        public long? EchoNullableInt64(long? value)
+        {
+            return value;
+        }
+
+        public ulong? EchoNullableUInt64(ulong? value)
+        {
+            return value;
+        }
+
+        public float? EchoNullableSingle(float? value)
+        {
+            return value;
+        }
+
+        public double? EchoNullableDouble(double? value)
+        {
+            return value;
+        }
+
+        public decimal? EchoNullableDecimal(decimal? value)
+        {
+            return value;
+        }
+
+        public DateTime? EchoNullableDateTime(DateTime? value)
+        {
+            return value;
+        }
+
+        public DateTimeOffset? EchoNullableDateTimeOffset(DateTimeOffset? value)
+        {
+            return value;
+        }
+
+        public TimeSpan? EchoNullableTimeSpan(TimeSpan? value)
+        {
+            return value;
+        }
+
+        public Guid? EchoNullableGuid(Guid? value)
+        {
+            return value;
+        }
+
+        public PrimitiveEnum? EchoNullableEnum(PrimitiveEnum? value)
+        {
+            return value;
+        }
+
+        public char? EchoNullableChar(char? value)
+        {
+            return value;
+        }
+
+        public string EchoString(string value)
+        {
+            return value;
+        }
+    }
+}

--- a/Swashbuckle.Dummy.Core/SwaggerExtensions/ApplySchemaVendorExtensions.cs
+++ b/Swashbuckle.Dummy.Core/SwaggerExtensions/ApplySchemaVendorExtensions.cs
@@ -7,7 +7,12 @@ namespace Swashbuckle.Dummy.SwaggerExtensions
     {
         public void Apply(Schema schema, SchemaRegistry schemaRegistry, Type type)
         {
-            schema.vendorExtensions.Add("x-schema", "bar");
+            if (type.IsArray && type.GetElementType() != typeof(byte)) return; // Special case
+
+            var nullableUnderlyingType = Nullable.GetUnderlyingType(type);
+
+            schema.vendorExtensions.Add("x-type-dotnet", (nullableUnderlyingType ?? type).FullName);
+            schema.vendorExtensions.Add("x-nullable", nullableUnderlyingType != null || !type.IsValueType);
         }
     }
 }

--- a/Swashbuckle.Dummy.Core/Swashbuckle.Dummy.Core.csproj
+++ b/Swashbuckle.Dummy.Core/Swashbuckle.Dummy.Core.csproj
@@ -77,6 +77,8 @@
     <Compile Include="Controllers\NullableTypesController.cs" />
     <Compile Include="Controllers\ObsoletePropertiesController.cs" />
     <Compile Include="Controllers\PathRequiredController.cs" />
+    <Compile Include="Controllers\PrimitiveArrayTypesController.cs" />
+    <Compile Include="Controllers\PrimitiveTypesController.cs" />
     <Compile Include="Controllers\ProtectedResourcesController.cs" />
     <Compile Include="Controllers\SelfReferencingTypesController.cs" />
     <Compile Include="Controllers\CustomersController.cs" />
@@ -105,6 +107,7 @@
     <Compile Include="SwaggerExtensions\AddGetMessageExamples.cs" />
     <Compile Include="SwaggerExtensions\SupportFlaggedEnums.cs" />
     <Compile Include="SwaggerExtensions\UpdateFileDownloadOperations.cs" />
+    <Compile Include="Types\PrimitiveEnum.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="App_Start\SwaggerConfig.cs" />

--- a/Swashbuckle.Dummy.Core/Types/PrimitiveEnum.cs
+++ b/Swashbuckle.Dummy.Core/Types/PrimitiveEnum.cs
@@ -1,0 +1,7 @@
+﻿namespace Swashbuckle.Dummy.Types
+{
+    public enum PrimitiveEnum
+    {
+        OneFish, TwoFish, RedFish, BlueFish
+    }
+}

--- a/Swashbuckle.Tests/Swagger/SchemaTests.cs
+++ b/Swashbuckle.Tests/Swagger/SchemaTests.cs
@@ -309,6 +309,7 @@ namespace Swashbuckle.Tests.Swagger
             {
                 c.MapType<Guid>(() => new Schema { type = "string", format = "guid" }); // map format to guid instead of uuid
                 c.SchemaFilter<ApplySchemaVendorExtensions>();
+                c.ApplyFiltersToAllSchemas();
             });
 
             var swagger = GetContent<JObject>("http://tempuri.org/swagger/docs/v1");
@@ -392,6 +393,7 @@ namespace Swashbuckle.Tests.Swagger
                     c.DescribeAllEnumsAsStrings();
                 }
                 c.SchemaFilter<ApplySchemaVendorExtensions>();
+                c.ApplyFiltersToAllSchemas();
             });
 
             var swagger = GetContent<JObject>("http://tempuri.org/swagger/docs/v1");
@@ -487,6 +489,7 @@ namespace Swashbuckle.Tests.Swagger
                     c.DescribeAllEnumsAsStrings();
                 }
                 c.SchemaFilter<ApplySchemaVendorExtensions>();
+                c.ApplyFiltersToAllSchemas();
             });
 
             var swagger = GetContent<JObject>("http://tempuri.org/swagger/docs/v1");

--- a/Swashbuckle.Tests/Swagger/SchemaTests.cs
+++ b/Swashbuckle.Tests/Swagger/SchemaTests.cs
@@ -9,6 +9,7 @@ using Swashbuckle.Dummy.Controllers;
 using Swashbuckle.Application;
 using Swashbuckle.Swagger;
 using Swashbuckle.Dummy.SwaggerExtensions;
+using Swashbuckle.Dummy.Types;
 
 namespace Swashbuckle.Tests.Swagger
 {
@@ -301,16 +302,255 @@ namespace Swashbuckle.Tests.Swagger
         }
 
         [Test]
-        public void It_exposes_config_to_post_modify_schemas()
+        public void It_exposes_config_to_post_modify_schemas_for_mapped_types()
         {
-            SetUpDefaultRouteFor<ProductsController>();
-            SetUpHandler(c => c.SchemaFilter<ApplySchemaVendorExtensions>());
+            SetUpCustomRouteFor<PrimitiveTypesController>("PrimitiveTypes/{action}");
+            SetUpHandler(c =>
+            {
+                c.MapType<Guid>(() => new Schema { type = "string", format = "guid" }); // map format to guid instead of uuid
+                c.SchemaFilter<ApplySchemaVendorExtensions>();
+            });
 
             var swagger = GetContent<JObject>("http://tempuri.org/swagger/docs/v1");
-            var xProp = swagger["definitions"]["Product"]["x-schema"];
+            var operation = swagger["paths"]["/PrimitiveTypes/EchoGuid"]["post"];
+            var parameter = operation["parameters"][0];
+            var response = operation["responses"]["200"]["schema"];
 
-            Assert.IsNotNull(xProp);
-            Assert.AreEqual("bar", xProp.ToString());
+            var method = typeof(PrimitiveTypesController).GetMethod("EchoGuid");
+            Assert.AreEqual(typeof(Guid), method.GetParameters()[0].ParameterType);
+            Assert.AreEqual(typeof(Guid), method.ReturnType);
+
+            var expectedParameter = new Dictionary<string, object>
+            {
+                { "name", "value" },
+                { "in", "query" },
+                { "required", true },
+                { "type", "string" },
+                { "format", "guid" },
+                { "x-type-dotnet", "System.Guid" },
+                { "x-nullable", false }
+            };
+            Assert.AreEqual(JObject.FromObject(expectedParameter).ToString(), parameter.ToString());
+
+            var expectedResponse = new Dictionary<string, object>()
+            {
+                { "format", "guid" },
+                { "type", "string" },
+                { "x-type-dotnet", "System.Guid" },
+                { "x-nullable", false }
+            };
+            Assert.AreEqual(JObject.FromObject(expectedResponse).ToString(), response.ToString());
+        }
+
+        [TestCase("EchoBoolean", typeof(bool), "boolean", null, "System.Boolean", false)]
+        [TestCase("EchoByte", typeof(byte), "integer", "int32", "System.Byte", false)]
+        [TestCase("EchoSByte", typeof(sbyte), "integer", "int32", "System.SByte", false)]
+        [TestCase("EchoInt16", typeof(short), "integer", "int32", "System.Int16", false)]
+        [TestCase("EchoUInt16", typeof(ushort), "integer", "int32", "System.UInt16", false)]
+        [TestCase("EchoInt32", typeof(int), "integer", "int32", "System.Int32", false)]
+        [TestCase("EchoUInt32", typeof(uint), "integer", "int32", "System.UInt32", false)]
+        [TestCase("EchoInt64", typeof(long), "integer", "int64", "System.Int64", false)]
+        [TestCase("EchoUInt64", typeof(ulong), "integer", "int64", "System.UInt64", false)]
+        [TestCase("EchoSingle", typeof(float), "number", "float", "System.Single", false)]
+        [TestCase("EchoDouble", typeof(double), "number", "double", "System.Double", false)]
+        [TestCase("EchoDecimal", typeof(decimal), "number", "double", "System.Decimal", false)]
+        [TestCase("EchoDateTime", typeof(DateTime), "string", "date-time", "System.DateTime", false)]
+        [TestCase("EchoDateTimeOffset", typeof(DateTimeOffset), "string", "date-time", "System.DateTimeOffset", false)]
+        [TestCase("EchoTimeSpan", typeof(TimeSpan), "string", null, "System.TimeSpan", false)]
+        [TestCase("EchoGuid", typeof(Guid), "string", "uuid", "System.Guid", false)]
+        [TestCase("EchoEnum", typeof(PrimitiveEnum), "integer", "int32", "Swashbuckle.Dummy.Types.PrimitiveEnum", false)]
+        [TestCase("EchoEnum", typeof(PrimitiveEnum), "string", null, "Swashbuckle.Dummy.Types.PrimitiveEnum", false)]
+        [TestCase("EchoChar", typeof(char), "string", null, "System.Char", false)]
+        [TestCase("EchoNullableBoolean", typeof(bool?), "boolean", null, "System.Boolean", true)]
+        [TestCase("EchoNullableByte", typeof(byte?), "integer", "int32", "System.Byte", true)]
+        [TestCase("EchoNullableSByte", typeof(sbyte?), "integer", "int32", "System.SByte", true)]
+        [TestCase("EchoNullableInt16", typeof(short?), "integer", "int32", "System.Int16", true)]
+        [TestCase("EchoNullableUInt16", typeof(ushort?), "integer", "int32", "System.UInt16", true)]
+        [TestCase("EchoNullableInt32", typeof(int?), "integer", "int32", "System.Int32", true)]
+        [TestCase("EchoNullableUInt32", typeof(uint?), "integer", "int32", "System.UInt32", true)]
+        [TestCase("EchoNullableInt64", typeof(long?), "integer", "int64", "System.Int64", true)]
+        [TestCase("EchoNullableUInt64", typeof(ulong?), "integer", "int64", "System.UInt64", true)]
+        [TestCase("EchoNullableSingle", typeof(float?), "number", "float", "System.Single", true)]
+        [TestCase("EchoNullableDouble", typeof(double?), "number", "double", "System.Double", true)]
+        [TestCase("EchoNullableDecimal", typeof(decimal?), "number", "double", "System.Decimal", true)]
+        [TestCase("EchoNullableDateTime", typeof(DateTime?), "string", "date-time", "System.DateTime", true)]
+        [TestCase("EchoNullableDateTimeOffset", typeof(DateTimeOffset?), "string", "date-time", "System.DateTimeOffset", true)]
+        [TestCase("EchoNullableTimeSpan", typeof(TimeSpan?), "string", null, "System.TimeSpan", true)]
+        [TestCase("EchoNullableGuid", typeof(Guid?), "string", "uuid", "System.Guid", true)]
+        [TestCase("EchoNullableEnum", typeof(PrimitiveEnum?), "integer", "int32", "Swashbuckle.Dummy.Types.PrimitiveEnum", true)]
+        [TestCase("EchoNullableEnum", typeof(PrimitiveEnum?), "string", null, "Swashbuckle.Dummy.Types.PrimitiveEnum", true)]
+        [TestCase("EchoNullableChar", typeof(char?), "string", null, "System.Char", true)]
+        [TestCase("EchoString", typeof(string), "string", null, "System.String", true)]
+        public void It_exposes_config_to_post_modify_schemas_for_primitives(string action, Type dotNetType, string type, string format, string xtypeDotNet, bool xnullable)
+        {
+            var underlyingDotNetType = Nullable.GetUnderlyingType(dotNetType) ?? dotNetType;
+            SetUpCustomRouteFor<PrimitiveTypesController>("PrimitiveTypes/{action}");
+            SetUpHandler(c =>
+            {
+                if (underlyingDotNetType.IsEnum && type == "string")
+                {
+                    c.DescribeAllEnumsAsStrings();
+                }
+                c.SchemaFilter<ApplySchemaVendorExtensions>();
+            });
+
+            var swagger = GetContent<JObject>("http://tempuri.org/swagger/docs/v1");
+            var operation = swagger["paths"]["/PrimitiveTypes/" + action]["post"];
+            var parameter = operation["parameters"][0];
+            var response = operation["responses"]["200"]["schema"];
+
+            var method = typeof(PrimitiveTypesController).GetMethod(action);
+            Assert.AreEqual(dotNetType, method.GetParameters()[0].ParameterType);
+            Assert.AreEqual(dotNetType, method.ReturnType);
+
+            var expectedParameter = new Dictionary<string, object>
+            {
+                { "name", "value" },
+                { "in", "query" },
+                { "required", true },
+                { "type", type }
+            };
+            if (format != null)
+            {
+                expectedParameter.Add("format", format);
+            }
+            if (underlyingDotNetType.IsEnum)
+            {
+                expectedParameter.Add("enum", type == "string" ? underlyingDotNetType.GetEnumNames() : underlyingDotNetType.GetEnumValues());
+            }
+            expectedParameter.Add("x-type-dotnet", xtypeDotNet);
+            expectedParameter.Add("x-nullable", xnullable);
+            Assert.AreEqual(JObject.FromObject(expectedParameter).ToString(), parameter.ToString());
+
+            var expectedResponse = new Dictionary<string, object>();
+            if (format != null)
+            {
+                expectedResponse.Add("format", format);
+            }
+            if (underlyingDotNetType.IsEnum)
+            {
+                expectedResponse.Add("enum", type == "string" ? underlyingDotNetType.GetEnumNames() : underlyingDotNetType.GetEnumValues());
+            }
+            expectedResponse.Add("type", type);
+            expectedResponse.Add("x-type-dotnet", xtypeDotNet);
+            expectedResponse.Add("x-nullable", xnullable);
+            Assert.AreEqual(JObject.FromObject(expectedResponse).ToString(), response.ToString());
+        }
+
+        [TestCase("EchoBoolean", typeof(bool), "boolean", null, "System.Boolean", false)]
+        [TestCase("EchoByte", typeof(byte), "string", "byte", "System.Byte[]", true)] // Special case
+        [TestCase("EchoSByte", typeof(sbyte), "integer", "int32", "System.SByte", false)]
+        [TestCase("EchoInt16", typeof(short), "integer", "int32", "System.Int16", false)]
+        [TestCase("EchoUInt16", typeof(ushort), "integer", "int32", "System.UInt16", false)]
+        [TestCase("EchoInt32", typeof(int), "integer", "int32", "System.Int32", false)]
+        [TestCase("EchoUInt32", typeof(uint), "integer", "int32", "System.UInt32", false)]
+        [TestCase("EchoInt64", typeof(long), "integer", "int64", "System.Int64", false)]
+        [TestCase("EchoUInt64", typeof(ulong), "integer", "int64", "System.UInt64", false)]
+        [TestCase("EchoSingle", typeof(float), "number", "float", "System.Single", false)]
+        [TestCase("EchoDouble", typeof(double), "number", "double", "System.Double", false)]
+        [TestCase("EchoDecimal", typeof(decimal), "number", "double", "System.Decimal", false)]
+        [TestCase("EchoDateTime", typeof(DateTime), "string", "date-time", "System.DateTime", false)]
+        [TestCase("EchoDateTimeOffset", typeof(DateTimeOffset), "string", "date-time", "System.DateTimeOffset", false)]
+        [TestCase("EchoTimeSpan", typeof(TimeSpan), "string", null, "System.TimeSpan", false)]
+        [TestCase("EchoGuid", typeof(Guid), "string", "uuid", "System.Guid", false)]
+        [TestCase("EchoEnum", typeof(PrimitiveEnum), "integer", "int32", "Swashbuckle.Dummy.Types.PrimitiveEnum", false)]
+        [TestCase("EchoEnum", typeof(PrimitiveEnum), "string", null, "Swashbuckle.Dummy.Types.PrimitiveEnum", false)]
+        [TestCase("EchoChar", typeof(char), "string", null, "System.Char", false)]
+        [TestCase("EchoNullableBoolean", typeof(bool?), "boolean", null, "System.Boolean", true)]
+        [TestCase("EchoNullableByte", typeof(byte?), "integer", "int32", "System.Byte", true)]
+        [TestCase("EchoNullableSByte", typeof(sbyte?), "integer", "int32", "System.SByte", true)]
+        [TestCase("EchoNullableInt16", typeof(short?), "integer", "int32", "System.Int16", true)]
+        [TestCase("EchoNullableUInt16", typeof(ushort?), "integer", "int32", "System.UInt16", true)]
+        [TestCase("EchoNullableInt32", typeof(int?), "integer", "int32", "System.Int32", true)]
+        [TestCase("EchoNullableUInt32", typeof(uint?), "integer", "int32", "System.UInt32", true)]
+        [TestCase("EchoNullableInt64", typeof(long?), "integer", "int64", "System.Int64", true)]
+        [TestCase("EchoNullableUInt64", typeof(ulong?), "integer", "int64", "System.UInt64", true)]
+        [TestCase("EchoNullableSingle", typeof(float?), "number", "float", "System.Single", true)]
+        [TestCase("EchoNullableDouble", typeof(double?), "number", "double", "System.Double", true)]
+        [TestCase("EchoNullableDecimal", typeof(decimal?), "number", "double", "System.Decimal", true)]
+        [TestCase("EchoNullableDateTime", typeof(DateTime?), "string", "date-time", "System.DateTime", true)]
+        [TestCase("EchoNullableDateTimeOffset", typeof(DateTimeOffset?), "string", "date-time", "System.DateTimeOffset", true)]
+        [TestCase("EchoNullableTimeSpan", typeof(TimeSpan?), "string", null, "System.TimeSpan", true)]
+        [TestCase("EchoNullableGuid", typeof(Guid?), "string", "uuid", "System.Guid", true)]
+        [TestCase("EchoNullableEnum", typeof(PrimitiveEnum?), "integer", "int32", "Swashbuckle.Dummy.Types.PrimitiveEnum", true)]
+        [TestCase("EchoNullableEnum", typeof(PrimitiveEnum?), "string", null, "Swashbuckle.Dummy.Types.PrimitiveEnum", true)]
+        [TestCase("EchoNullableChar", typeof(char?), "string", null, "System.Char", true)]
+        [TestCase("EchoString", typeof(string), "string", null, "System.String", true)]
+        public void It_exposes_config_to_post_modify_schemas_for_primitive_arrays(string action, Type dotNetType, string type, string format, string xtypeDotNet, bool xnullable)
+        {
+            var underlyingDotNetType = Nullable.GetUnderlyingType(dotNetType) ?? dotNetType;
+            SetUpCustomRouteFor<PrimitiveArrayTypesController>("PrimitiveArrayTypes/{action}");
+            SetUpHandler(c =>
+            {
+                if (underlyingDotNetType.IsEnum && type == "string")
+                {
+                    c.DescribeAllEnumsAsStrings();
+                }
+                c.SchemaFilter<ApplySchemaVendorExtensions>();
+            });
+
+            var swagger = GetContent<JObject>("http://tempuri.org/swagger/docs/v1");
+            var operation = swagger["paths"]["/PrimitiveArrayTypes/" + action]["post"];
+            var parameter = operation["parameters"][0];
+            var response = operation["responses"]["200"]["schema"];
+
+            var method = typeof(PrimitiveArrayTypesController).GetMethod(action);
+            Assert.AreEqual(dotNetType.MakeArrayType(), method.GetParameters()[0].ParameterType);
+            Assert.AreEqual(dotNetType.MakeArrayType(), method.ReturnType);
+
+            var expectedParameterItems = new Dictionary<string, object>();
+            if (format != null)
+            {
+                expectedParameterItems.Add("format", format);
+            }
+            if (underlyingDotNetType.IsEnum)
+            {
+                expectedParameterItems.Add("enum", type == "string" ? underlyingDotNetType.GetEnumNames() : underlyingDotNetType.GetEnumValues());
+            }
+            expectedParameterItems.Add("type", type);
+            expectedParameterItems.Add("x-type-dotnet", xtypeDotNet);
+            expectedParameterItems.Add("x-nullable", xnullable);
+            var expectedParameter = (format == "byte") // Special case
+                ? JObject.FromObject(new
+                {
+                    name = "value",
+                    @in = "body",
+                    required = true,
+                    schema = expectedParameterItems
+                })
+                : JObject.FromObject(new
+                {
+                    name = "value",
+                    @in = "body",
+                    required = true,
+                    schema = new
+                    {
+                        type = "array",
+                        items = expectedParameterItems
+                    }
+                });
+            Assert.AreEqual(expectedParameter.ToString(), parameter.ToString());
+
+            var expectedResponseItems = new Dictionary<string, object>();
+            if (format != null)
+            {
+                expectedResponseItems.Add("format", format);
+            }
+            if (underlyingDotNetType.IsEnum)
+            {
+                expectedResponseItems.Add("enum", type == "string" ? underlyingDotNetType.GetEnumNames() : underlyingDotNetType.GetEnumValues());
+            }
+            expectedResponseItems.Add("type", type);
+            expectedResponseItems.Add("x-type-dotnet", xtypeDotNet);
+            expectedResponseItems.Add("x-nullable", xnullable);
+            var expectedResponse = (format == "byte") // Special case
+                ? JObject.FromObject(expectedResponseItems)
+                : JObject.FromObject(new
+                {
+                    type = "array",
+                    items = expectedResponseItems
+                });
+            Assert.AreEqual(expectedResponse.ToString(), response.ToString());
         }
 
         [Test]


### PR DESCRIPTION
Following up from #776; make `ISchemaFilter` available for all types.

Unit tests use a `ISchemaFilter` to demonstrate this for all primitives (including enums), composites and arrays, including with nullable types, used in parameters and request / response types.

This could be made available in a separate AutoRest extension as follows:
```c#
public class XmsTypeDotNetSchemaFilter : ISchemaFilter
{
    public void Apply(Schema schema, SchemaRegistry schemaRegistry, Type type)
    {
        if (type.IsArray && type.GetElementType() != typeof(byte)) return; // Special case

        var nullableUnderlyingType = Nullable.GetUnderlyingType(type);

        schema.vendorExtensions.Add("x-type-dotnet", (nullableUnderlyingType ?? type).FullName);
        schema.vendorExtensions.Add("x-nullable", nullableUnderlyingType != null || !type.IsValueType);
    }
}
```
Also, x-ms-enum support could now be applied using an `ISchemaFilter` as follows:
```c#
public class XmsEnumSchemaFilter : ISchemaFilter
{
    public void Apply(Schema schema, SchemaRegistry schemaRegistry, Type type)
    {
        type = Nullable.GetUnderlyingType(type) ?? type;

        if (type.IsEnum)
        {
            schema.vendorExtensions.Add("x-ms-enum", new { name = type.Name });
        }
    }
}
```
And "required" properties could be derived from non-nullable properties as follows:
```c#
public static class SchemaExtensions
{
    public static bool IsNullable(this Schema schema)
    {
        object value;
        return (schema.vendorExtensions != null) && schema.vendorExtensions.TryGetValue("x-nullable", out value) && (value is bool) && (bool)value;
    }
}

public class RequiredSchemaFilter : ISchemaFilter
{
    public void Apply(Schema schema, SchemaRegistry schemaRegistry, Type type)
    {
        var required = schema.properties?.Where(x => !x.Value.IsNullable())
            .Select(x => x.Key)
            .ToArray();

        if (required?.Length > 0)
        {
            if (schema.required == null)
            {
                schema.required = new List<string>();
            }
            foreach (var property in required)
            {
                schema.required.Add(property);
            }
        }
    }
}
```