### PR TITLE
Fix loading params docu from XML when overriding parameter name with …

### DIFF
--- a/Swashbuckle.Dummy.Core/Controllers/XmlAnnotatedController.cs
+++ b/Swashbuckle.Dummy.Core/Controllers/XmlAnnotatedController.cs
@@ -30,7 +30,7 @@ namespace Swashbuckle.Dummy.Controllers
         }
 
         /// <summary>
-        /// Search all registered accounts by keywords 
+        /// Search all registered accounts by keywords
         /// </summary>
         /// <remarks>Restricted to admin users only</remarks>
         /// <param name="keywords">List of search keywords</param>
@@ -49,7 +49,7 @@ namespace Swashbuckle.Dummy.Controllers
         /// <returns></returns>
         [HttpGet]
         [Route("filter")]
-        public IEnumerable<Account> Filter(string q, [FromUri]Page page)
+        public IEnumerable<Account> Filter([FromUri(Name = "$q")]string q, [FromUri]Page page)
         {
             throw new NotImplementedException();
         }
@@ -77,7 +77,7 @@ namespace Swashbuckle.Dummy.Controllers
         }
 
         /// <summary>
-        /// Updates metadata associated with an account 
+        /// Updates metadata associated with an account
         /// </summary>
         /// <param name="id"></param>
         /// <param name="metadata"></param>
@@ -111,7 +111,7 @@ namespace Swashbuckle.Dummy.Controllers
         /// The ID for Accounts is 5 digits long.
         /// </summary>
         public virtual int AccountID { get; set; }
-        
+
         /// <summary>
         /// Uniquely identifies the account
         /// </summary>
@@ -135,7 +135,7 @@ namespace Swashbuckle.Dummy.Controllers
             /// Flag to indicate if marketing emails may be sent
             /// </summary>
             [JsonProperty("allow-marketing-emails")]
-            public string AllowMarketingEmails { get; set; }            
+            public string AllowMarketingEmails { get; set; }
         }
     }
 
@@ -157,7 +157,7 @@ namespace Swashbuckle.Dummy.Controllers
     public class Reward<T>
     {
         /// <summary>
-        /// The monetary value of the reward 
+        /// The monetary value of the reward
         /// </summary>
         public decimal value;
 

--- a/Swashbuckle.Dummy.Core/XmlComments.xml
+++ b/Swashbuckle.Dummy.Core/XmlComments.xml
@@ -20,7 +20,7 @@
         </member>
         <member name="M:Swashbuckle.Dummy.Controllers.XmlAnnotatedController.Search(System.Collections.Generic.IEnumerable{System.String})">
             <summary>
-            Search all registered accounts by keywords 
+            Search all registered accounts by keywords
             </summary>
             <remarks>Restricted to admin users only</remarks>
             <param name="keywords">List of search keywords</param>
@@ -48,7 +48,7 @@
         </member>
         <member name="M:Swashbuckle.Dummy.Controllers.XmlAnnotatedController.UpdateMetadata(System.Int32,System.Collections.Generic.KeyValuePair{System.String,System.String}[])">
             <summary>
-            Updates metadata associated with an account 
+            Updates metadata associated with an account
             </summary>
             <param name="id"></param>
             <param name="metadata"></param>
@@ -111,7 +111,7 @@
         </member>
         <member name="F:Swashbuckle.Dummy.Controllers.Reward`1.value">
             <summary>
-            The monetary value of the reward 
+            The monetary value of the reward
             </summary>
         </member>
         <member name="P:Swashbuckle.Dummy.Controllers.Reward`1.RewardType">

--- a/Swashbuckle.Dummy.WebHost/XmlComments.xml
+++ b/Swashbuckle.Dummy.WebHost/XmlComments.xml
@@ -20,7 +20,7 @@
         </member>
         <member name="M:Swashbuckle.Dummy.Controllers.XmlAnnotatedController.Search(System.Collections.Generic.IEnumerable{System.String})">
             <summary>
-            Search all registered accounts by keywords 
+            Search all registered accounts by keywords
             </summary>
             <remarks>Restricted to admin users only</remarks>
             <param name="keywords">List of search keywords</param>
@@ -48,7 +48,7 @@
         </member>
         <member name="M:Swashbuckle.Dummy.Controllers.XmlAnnotatedController.UpdateMetadata(System.Int32,System.Collections.Generic.KeyValuePair{System.String,System.String}[])">
             <summary>
-            Updates metadata associated with an account 
+            Updates metadata associated with an account
             </summary>
             <param name="id"></param>
             <param name="metadata"></param>
@@ -111,7 +111,7 @@
         </member>
         <member name="F:Swashbuckle.Dummy.Controllers.Reward`1.value">
             <summary>
-            The monetary value of the reward 
+            The monetary value of the reward
             </summary>
         </member>
         <member name="P:Swashbuckle.Dummy.Controllers.Reward`1.RewardType">


### PR DESCRIPTION
When using the FromUri attribute to override names of parameters on the URI the comment was not looked up correctly. Here is the fix.