### PR TITLE
Support xml cref

### DIFF
--- a/Swashbuckle.Core/Swagger/XmlComments/ApplyXmlActionComments.cs
+++ b/Swashbuckle.Core/Swagger/XmlComments/ApplyXmlActionComments.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Reflection;
 using System.Web.Http.Controllers;
 using System.Web.Http.Description;
 using System.Xml.XPath;
@@ -41,7 +42,7 @@ namespace Swashbuckle.Swagger.XmlComments
 
             ApplyParamComments(operation, methodNode);
 
-            ApplyResponseComments(operation, methodNode);
+            ApplyResponseComments(operation, schemaRegistry, methodNode);
         }
 
         private static void ApplyParamComments(Operation operation, XPathNavigator methodNode)
@@ -58,28 +59,63 @@ namespace Swashbuckle.Swagger.XmlComments
             }
         }
 
-        private static void ApplyResponseComments(Operation operation, XPathNavigator methodNode)
+        private static void ApplyResponseComments(Operation operation, SchemaRegistry schemaRegistry, XPathNavigator methodNode)
         {
             var responseNodes = methodNode.Select(ResponseTag);
 
-            if (responseNodes.Count > 0)
+            if (responseNodes.Count <= 0) return;
+
+            var successResponse = operation.responses.First().Value;
+            operation.responses.Clear();
+
+            while (responseNodes.MoveNext())
             {
-                var successResponse = operation.responses.First().Value;
-                operation.responses.Clear();
+                var statusCode = responseNodes.Current.GetAttribute("code", string.Empty);
+                var description = responseNodes.Current.ExtractContent();
 
-                while (responseNodes.MoveNext())
+                var responseTypeName = responseNodes.Current.GetAttribute("cref", string.Empty);
+                var schema = responseTypeName == string.Empty
+                    ? (statusCode.StartsWith("2") 
+                        ? successResponse.schema 
+                        : null
+                    )
+                    : GetCrefSchema(schemaRegistry, responseTypeName.Substring(2));
+                var response = new Response
                 {
-                    var statusCode = responseNodes.Current.GetAttribute("code", "");
-                    var description = responseNodes.Current.ExtractContent();
-
-                    var response = new Response
-                    {
-                        description = description,
-                        schema = statusCode.StartsWith("2") ? successResponse.schema : null
-                    };
-                    operation.responses[statusCode] = response;
-                }
+                    description = description,
+                    schema = schema
+                };
+                operation.responses[statusCode] = response;
             }
+        }
+
+        private static Schema GetCrefSchema(SchemaRegistry schemaRegistry, string responseTypeName)
+        {
+            Schema schema ;
+            if (schemaRegistry.Definitions.TryGetValue(responseTypeName, out schema))
+            {
+                return schema;
+            }
+            
+            var responseType = GetType(responseTypeName);
+            if (responseType == null)
+                throw new Exception($"Could not resolve type {responseTypeName}");
+            schema = schemaRegistry.GetOrRegister(responseType);
+            return schema;
+        }
+
+        private static Assembly[] _assemblies = AppDomain.CurrentDomain.GetAssemblies();
+        private static Type GetType(string typeName)
+        {
+            var type = Type.GetType(typeName);
+            if (type != null) return type;
+            foreach (var assembly in _assemblies)
+            {
+                type = assembly.GetType(typeName);
+                if (type != null)
+                    return type;
+            }
+            return null;
         }
     }
 }


### PR DESCRIPTION
Added support for <respomse> xml comment to have a cref to indicate the Model Type.
And support for System.Web.Http.HttpError Type in the schema registry

This allows us not to need the Swashbuckle dll on the Web Api controller dlls. makes it less tightly coupled and more plug-able towards better Solid principles.