### PR TITLE
Oauth2 spec does not allow redirect uris to contain a fragment component

### DIFF
--- a/Swashbuckle.Core/SwaggerUi/CustomAssets/index.html
+++ b/Swashbuckle.Core/SwaggerUi/CustomAssets/index.html
@@ -107,7 +107,7 @@
         apisSorter: null, // default to server
         defaultModelRendering: 'schema',
         showRequestHeaders: false,
-        oauth2RedirectUrl: window.location.href.replace('index', 'o2c-html')
+        oauth2RedirectUrl: window.location.href.replace('index', 'o2c-html').split('#')[0]
       });
 
       if (window.swashbuckleConfig.validatorUrl !== '')


### PR DESCRIPTION
See https://tools.ietf.org/html/rfc6749 section 3.1.2.

Without the fix this pull request proposes, invalid `redirect_uri`s are generated such as: 
`http://localhost:49242/swagger/ui/o2c-html#!/Assets/Assets_GetAll`