### PR TITLE
Removing URI encoding from ApiKey sent out in HTTP header.

### DIFF
--- a/Swashbuckle.Core/SwaggerUi/CustomAssets/index.html
+++ b/Swashbuckle.Core/SwaggerUi/CustomAssets/index.html
@@ -114,7 +114,7 @@
         window.swaggerUi.options.validatorUrl = window.swashbuckleConfig.validatorUrl;
 
       function addApiKeyAuthorization() {
-        var key = encodeURIComponent($('#input_apiKey')[0].value);
+        var key = $('#input_apiKey')[0].value;
         if (key && key.trim() != "") {
           var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization(swashbuckleConfig.apiKeyName, key, swashbuckleConfig.apiKeyIn);
           window.swaggerUi.api.clientAuthorizations.add("api_key", apiKeyAuth);


### PR DESCRIPTION
Proposing this PR to resolve https://github.com/domaindrivendev/Swashbuckle/issues/851.

**Warning**: Tested this to work when the Api Key is used in "header" mode. I have a feeling this will cause problems if the Api Key has a whitespace and is used in "query" (query string) mode. 