### PR TITLE
Only "URI encoding" ApiKey when in "query" mode.

### DIFF
--- a/Swashbuckle.Core/SwaggerUi/CustomAssets/index.html
+++ b/Swashbuckle.Core/SwaggerUi/CustomAssets/index.html
@@ -116,6 +116,9 @@
       function addApiKeyAuthorization() {
         var key = $('#input_apiKey')[0].value;
         if (key && key.trim() != "") {
+          if (swashbuckleConfig.apiKeyIn === "query") {
+              key = encodeURIComponent(key);
+          }
           var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization(swashbuckleConfig.apiKeyName, key, swashbuckleConfig.apiKeyIn);
           window.swaggerUi.api.clientAuthorizations.add("api_key", apiKeyAuth);
           log("added key " + key);

--- a/Swashbuckle.Core/SwaggerUi/CustomAssets/index.html
+++ b/Swashbuckle.Core/SwaggerUi/CustomAssets/index.html
@@ -114,7 +114,7 @@
         window.swaggerUi.options.validatorUrl = window.swashbuckleConfig.validatorUrl;
 
       function addApiKeyAuthorization() {
-        var key = encodeURIComponent($('#input_apiKey')[0].value);
+        var key = $('#input_apiKey')[0].value;
         if (key && key.trim() != "") {
           var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization(swashbuckleConfig.apiKeyName, key, swashbuckleConfig.apiKeyIn);
           window.swaggerUi.api.clientAuthorizations.add("api_key", apiKeyAuth);


### PR DESCRIPTION
Proposing this PR to resolve https://github.com/domaindrivendev/Swashbuckle/issues/851. 

The code change in this PR makes it so that when using ApiKey Authentication, the key value is URI encoded only when in "query" mode. In "header" mode the key value is not URI encoded thereby resolving said issue.