### PR TITLE
IncludeXmlComments causes massive performance issues

### DIFF
--- a/Swashbuckle.Core/Application/SwaggerDocsConfig.cs
+++ b/Swashbuckle.Core/Application/SwaggerDocsConfig.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Web.Http;
 using System.Web.Http.Description;
+using System.Xml.XPath;
 using Newtonsoft.Json.Converters;
 using Swashbuckle.Swagger;
 using Swashbuckle.Swagger.FromUriParams;
@@ -190,8 +191,9 @@ namespace Swashbuckle.Application
 
         public void IncludeXmlComments(string filePath)
         {
-            OperationFilter(() => new ApplyXmlActionComments(filePath));
-            ModelFilter(() => new ApplyXmlTypeComments(filePath));
+            var navigator = new Lazy<XPathNavigator>(()=> new XPathDocument(filePath).CreateNavigator());
+            OperationFilter(() => new ApplyXmlActionComments(navigator.Value));
+            ModelFilter(() => new ApplyXmlTypeComments(navigator.Value));
         }
 
         public void ResolveConflictingActions(Func<IEnumerable<ApiDescription>, ApiDescription> conflictingActionsResolver)

--- a/Swashbuckle.Core/Swagger/XmlComments/ApplyXmlActionComments.cs
+++ b/Swashbuckle.Core/Swagger/XmlComments/ApplyXmlActionComments.cs
@@ -25,6 +25,11 @@ namespace Swashbuckle.Swagger.XmlComments
             _navigator = new XPathDocument(xmlCommentsPath).CreateNavigator();
         }
 
+        public ApplyXmlActionComments(XPathNavigator xmlCommentsNavigator)
+        {
+            _navigator = xmlCommentsNavigator;
+        }
+
         public void Apply(Operation operation, SchemaRegistry schemaRegistry, ApiDescription apiDescription)
         {
             var methodNode = _navigator.SelectSingleNode(XPathFor(apiDescription.ActionDescriptor));

--- a/Swashbuckle.Core/Swagger/XmlComments/ApplyXmlTypeComments.cs
+++ b/Swashbuckle.Core/Swagger/XmlComments/ApplyXmlTypeComments.cs
@@ -22,6 +22,11 @@ namespace Swashbuckle.Swagger.XmlComments
             _navigator = new XPathDocument(xmlCommentsPath).CreateNavigator();
         }
 
+        public ApplyXmlTypeComments(XPathNavigator xmlCommentsNavigator)
+        {
+            _navigator = xmlCommentsNavigator;
+        }
+
         public void Apply(Schema model, ModelFilterContext context)
         {
             var typeNode = _navigator.SelectSingleNode(


### PR DESCRIPTION
Since the operation and model filters run each time the docs should be generated, the xml files are parsed into an XPathDocument/XPathNavigator at least twice per file. This is **very** time consuming if the files are large.

The Apply method could also be improved using a bit of code generation, but the XPathDocument modification is more important. 