### PR TITLE
Perf: IncludeXmlComments() shares XPathDocument instances.

### DIFF
--- a/Swashbuckle.Core/Application/SwaggerDocsConfig.cs
+++ b/Swashbuckle.Core/Application/SwaggerDocsConfig.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Web.Http;
 using System.Web.Http.Description;
+using System.Xml.XPath;
 using Newtonsoft.Json;
 using Swashbuckle.Swagger;
 using Swashbuckle.Swagger.Annotations;
@@ -210,8 +211,10 @@ namespace Swashbuckle.Application
 
         public void IncludeXmlComments(string filePath)
         {
-            OperationFilter(() => new ApplyXmlActionComments(filePath));
-            ModelFilter(() => new ApplyXmlTypeComments(filePath));
+            var lazyXmlDoc = new Lazy<XPathDocument>(() => new XPathDocument(filePath), isThreadSafe: true);
+
+            OperationFilter(() => new ApplyXmlActionComments(lazyXmlDoc.Value));
+            ModelFilter(() => new ApplyXmlTypeComments(lazyXmlDoc.Value));
         }
 
         public void ResolveConflictingActions(Func<IEnumerable<ApiDescription>, ApiDescription> conflictingActionsResolver)

--- a/Swashbuckle.Core/Swagger/XmlComments/ApplyXmlActionComments.cs
+++ b/Swashbuckle.Core/Swagger/XmlComments/ApplyXmlActionComments.cs
@@ -1,12 +1,9 @@
-﻿using System;
-using System.Diagnostics;
-using System.Linq;
+﻿using System.Linq;
 using System.Reflection;
 using System.Web.Http;
 using System.Web.Http.Controllers;
 using System.Web.Http.Description;
 using System.Xml.XPath;
-using Swashbuckle.Swagger;
 
 namespace Swashbuckle.Swagger.XmlComments
 {
@@ -17,12 +14,12 @@ namespace Swashbuckle.Swagger.XmlComments
         private const string RemarksXPath = "remarks";
         private const string ParamXPath = "param[@name='{0}']";
         private const string ResponseXPath = "response";
+        
+        private readonly XPathDocument _document;
 
-        private readonly XPathNavigator _navigator;
-
-        public ApplyXmlActionComments(string xmlCommentsPath)
+        public ApplyXmlActionComments(XPathDocument xmlCommentsDoc)
         {
-            _navigator = new XPathDocument(xmlCommentsPath).CreateNavigator();
+            _document = xmlCommentsDoc;
         }
 
         public void Apply(Operation operation, SchemaRegistry schemaRegistry, ApiDescription apiDescription)
@@ -30,8 +27,14 @@ namespace Swashbuckle.Swagger.XmlComments
             var reflectedActionDescriptor = apiDescription.ActionDescriptor as ReflectedHttpActionDescriptor;
             if (reflectedActionDescriptor == null) return;
 
+            XPathNavigator navigator;
+            lock (_document)
+            {
+                navigator = _document.CreateNavigator();
+            }
+
             var commentId = XmlCommentsIdHelper.GetCommentIdForMethod(reflectedActionDescriptor.MethodInfo);
-            var methodNode = _navigator.SelectSingleNode(string.Format(MemberXPath, commentId));
+            var methodNode = navigator.SelectSingleNode(string.Format(MemberXPath, commentId));
             if (methodNode == null) return;
 
             var summaryNode = methodNode.SelectSingleNode(SummaryXPath);

--- a/Swashbuckle.Core/Swagger/XmlComments/ApplyXmlActionComments.cs
+++ b/Swashbuckle.Core/Swagger/XmlComments/ApplyXmlActionComments.cs
@@ -14,8 +14,11 @@ namespace Swashbuckle.Swagger.XmlComments
         private const string RemarksXPath = "remarks";
         private const string ParamXPath = "param[@name='{0}']";
         private const string ResponseXPath = "response";
-        
+
         private readonly XPathDocument _document;
+
+        public ApplyXmlActionComments(string xmlCommentsPath)
+            : this(new XPathDocument(xmlCommentsPath)) { }
 
         public ApplyXmlActionComments(XPathDocument xmlCommentsDoc)
         {

--- a/Swashbuckle.Core/Swagger/XmlComments/ApplyXmlTypeComments.cs
+++ b/Swashbuckle.Core/Swagger/XmlComments/ApplyXmlTypeComments.cs
@@ -9,7 +9,10 @@ namespace Swashbuckle.Swagger.XmlComments
         private const string SummaryTag = "summary";
 
         private readonly XPathDocument _document;
-        
+
+        public ApplyXmlTypeComments(string xmlCommentsPath)
+            : this(new XPathDocument(xmlCommentsPath)) { }
+
         public ApplyXmlTypeComments(XPathDocument xmlCommentsDoc)
         {
             _document = xmlCommentsDoc;
@@ -45,7 +48,7 @@ namespace Swashbuckle.Swagger.XmlComments
             }
         }
 
-        private void ApplyPropertyComments(XPathNavigator navigator, Schema propertySchema, PropertyInfo propertyInfo)
+        private static void ApplyPropertyComments(XPathNavigator navigator, Schema propertySchema, PropertyInfo propertyInfo)
         {
             if (propertyInfo == null) return;
 


### PR DESCRIPTION
Improve performance of `swagger/docs/{version}` call when using XML comment documents.

Based off of https://github.com/domaindrivendev/Swashbuckle/pull/858