### PR TITLE
Fixes StackOverflowException in SchemaRegistry

### DIFF
--- a/Swashbuckle.Core/Swagger/SwaggerGenerator.cs
+++ b/Swashbuckle.Core/Swagger/SwaggerGenerator.cs
@@ -71,6 +71,8 @@ namespace Swashbuckle.Swagger
                 filter.Apply(swaggerDoc, schemaRegistry, _apiExplorer);
             }
 
+            schemaRegistry.FinializeSchema();
+
             return swaggerDoc;
         }
 


### PR DESCRIPTION
Fixes bug (#680) that causes a StackOverflowException to be thrown when calling
GetOrRegister on SchemaRegistry when in ISchemaFilter.Apply.