### PR TITLE
Fix to also check the Required property of the JsonProperty

### DIFF
--- a/Swashbuckle.Core/Swagger/JsonPropertyExtensions.cs
+++ b/Swashbuckle.Core/Swagger/JsonPropertyExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
 using System.Reflection;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
 namespace Swashbuckle.Swagger
@@ -9,7 +10,7 @@ namespace Swashbuckle.Swagger
     {
         public static bool IsRequired(this JsonProperty jsonProperty)
         {
-            return jsonProperty.HasAttribute<RequiredAttribute>();
+            return jsonProperty.HasAttribute<RequiredAttribute>() || jsonProperty.Required == Required.Always;
         }
 
         public static bool IsObsolete(this JsonProperty jsonProperty)


### PR DESCRIPTION
Fix to also check the Required property of the JsonProperty when determining if a model property is required or optional.
