### PR TITLE
Added FAQ for 500 error

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,7 @@ If you're using the existing configuration API to customize the final Swagger do
 6. [FromUri Query string DataMember names are incorrect](#fromuri-query-string-datamember-names-are-incorrect)
 7. [Remove Duplicate Path Parameters](#remove-duplicate-path-parameters)
 8. [Deploying behind Load Balancer / Reverse Proxies](#deploying-behind-load-balancer--reverse-proxies)
+9. [500 : {"Message":"An error has occurred."}](#)
 
 ### Swagger-ui showing "Can't read swagger JSON from ..."
 
@@ -655,6 +656,10 @@ public class ComplexTypeOperationFilter : IOperationFilter
 }
 ```
 
-### Deploying behind Load Balancer / Reverse Proxies ###
+### Deploying behind Load Balancer / Reverse Proxies
 
 Swashbuckle attempts to populate the [Swagger "host"](http://swagger.io/specification/#swaggerObject) property from HTTP headers that are sent with the request for Swagger JSON. This may cause issues in load balancer / reverse proxy environments, particularly if non-standard headers are used to pass on the outer most host name. You can workaround this by providing your own function for determining your API's root URL based on vendor-specific headers. Checkout #705 for some potential implementations.
+
+### 500 : {"Message":"An error has occurred."}
+
+If, on loading the Swagger UI page, you get an error: `500 : {"Message":"An error has occurred."} http://<url>/swagger/docs/v1` ensure that the XML documentation output settings have been set in the project file in the solution, for both Debug and Release configurations.

--- a/README.md
+++ b/README.md
@@ -504,7 +504,7 @@ If you're using the existing configuration API to customize the final Swagger do
 6. [FromUri Query string DataMember names are incorrect](#fromuri-query-string-datamember-names-are-incorrect)
 7. [Remove Duplicate Path Parameters](#remove-duplicate-path-parameters)
 8. [Deploying behind Load Balancer / Reverse Proxies](#deploying-behind-load-balancer--reverse-proxies)
-9. [500 : {"Message":"An error has occurred."}](#)
+9. [500 : {"Message":"An error has occurred."}](#500--messagean-error-has-occurred)
 
 ### Swagger-ui showing "Can't read swagger JSON from ..."
 


### PR DESCRIPTION
When XML documentation is required, but isn't configured correctly in the project file, you will get a 500 error. Added a note to the readme to catch this case.
