### PR TITLE
Usage of remarks on controllers to add tags description for resources

### DIFF
--- a/Swashbuckle.Core/Application/SwaggerDocsConfig.cs
+++ b/Swashbuckle.Core/Application/SwaggerDocsConfig.cs
@@ -248,11 +248,13 @@ namespace Swashbuckle.Application
             // custom filters AND so they can share the same XPathDocument (perf. optimization)
             var modelFilters = _modelFilters.Select(factory => factory()).ToList();
             var operationFilters = _operationFilters.Select(factory => factory()).ToList();
+            var documentFilters = _documentFilters.Select(factory => factory()).ToList();
             foreach (var xmlDocFactory in _xmlDocFactories)
             {
                 var xmlDoc = xmlDocFactory();
                 modelFilters.Insert(0, new ApplyXmlTypeComments(xmlDoc));
                 operationFilters.Insert(0, new ApplyXmlActionComments(xmlDoc));
+                documentFilters.Insert(0, new ApplyXmlResourceComments(xmlDoc));
             }
 
             var options = new SwaggerGeneratorOptions(
@@ -271,7 +273,7 @@ namespace Swashbuckle.Application
                 describeStringEnumsInCamelCase: _describeStringEnumsInCamelCase,
                 applyFiltersToAllSchemas: _applyFiltersToAllSchemas,
                 operationFilters: operationFilters,
-                documentFilters: _documentFilters.Select(factory => factory()),
+                documentFilters: documentFilters,
                 conflictingActionsResolver: _conflictingActionsResolver
             );
 

--- a/Swashbuckle.Dummy.Core/Controllers/XmlAnnotatedController.cs
+++ b/Swashbuckle.Dummy.Core/Controllers/XmlAnnotatedController.cs
@@ -5,6 +5,10 @@ using Newtonsoft.Json;
 
 namespace Swashbuckle.Dummy.Controllers
 {
+    /// <summary>
+    /// Xml Annotated Controller />.
+    /// </summary>
+    /// <remarks>Test tags on xml annotated controller</remarks>
     [RoutePrefix("xmlannotated")]
     public class XmlAnnotatedController : ApiController
     {

--- a/Swashbuckle.Dummy.Core/XmlComments.xml
+++ b/Swashbuckle.Dummy.Core/XmlComments.xml
@@ -4,6 +4,12 @@
         <name>Swashbuckle.Dummy.Core</name>
     </assembly>
     <members>
+        <member name="T:Swashbuckle.Dummy.Controllers.XmlAnnotatedController">
+            <summary>
+            Xml Annotated Controller />.
+            </summary>
+            <remarks>Test tags on xml annotated controller</remarks>
+        </member>
         <member name="M:Swashbuckle.Dummy.Controllers.XmlAnnotatedController.Create(Swashbuckle.Dummy.Controllers.Account)">
             <summary>
             Registers a new Account based on <paramref name="account"/>.

--- a/Swashbuckle.Dummy.WebHost/XmlComments.xml
+++ b/Swashbuckle.Dummy.WebHost/XmlComments.xml
@@ -4,6 +4,12 @@
         <name>Swashbuckle.Dummy.Core</name>
     </assembly>
     <members>
+        <member name="T:Swashbuckle.Dummy.Controllers.XmlAnnotatedController">
+            <summary>
+            Xml Annotated Controller />.
+            </summary>
+            <remarks>Test tags on xml annotated controller</remarks>
+        </member>
         <member name="M:Swashbuckle.Dummy.Controllers.XmlAnnotatedController.Create(Swashbuckle.Dummy.Controllers.Account)">
             <summary>
             Registers a new Account based on <paramref name="account"/>.

--- a/Swashbuckle.Tests/Swagger/XmlCommentsTests.cs
+++ b/Swashbuckle.Tests/Swagger/XmlCommentsTests.cs
@@ -162,6 +162,19 @@ namespace Swashbuckle.Tests.Swagger
         }
 
         [Test]
+        public void It_documents_schema_tags_from_controller_remarks_tags()
+        {
+            Configuration.Routes.Clear();
+            SetUpCustomRouteFor<XmlAnnotatedController>("XmlAnnotated/{id}/{action}");
+
+            var swagger = GetContent<JObject>("http://tempuri.org/swagger/docs/v1");
+            var tags = swagger["tags"];
+            Assert.IsNotNull(tags[0]);
+            Assert.AreEqual("XmlAnnotated", tags[0]["name"].ToString());
+            Assert.AreEqual("Test tags on xml annotated controller", tags[0]["description"].ToString());
+        }
+
+        [Test]
         public void It_handles_actions_with_array_of_generic_parameters()
         {
             var swagger = GetContent<JObject>("http://tempuri.org/swagger/docs/v1");


### PR DESCRIPTION
Hello,

We are working on a project with 2 version of the same api one in Java and other in .Net, we try to have a swagger as similar as possible and we miss the tags for the resources.

We found something about it in https://github.com/domaindrivendev/Swashbuckle/issues/217
but the solution is not correct.

Would be nice to add this little change.