### PR TITLE
Removes default ports from `DefaultRootUrlResolver` when applicable

### DIFF
--- a/Swashbuckle.Core/Application/SwaggerDocsConfig.cs
+++ b/Swashbuckle.Core/Application/SwaggerDocsConfig.cs
@@ -308,9 +308,11 @@ namespace Swashbuckle.Application
             var port = GetHeaderValue(request, "X-Forwarded-Port") ?? request.RequestUri.Port.ToString(CultureInfo.InvariantCulture);
 
             var httpConfiguration = request.GetConfiguration();
-            var virtualPathRoot = httpConfiguration.VirtualPathRoot.TrimEnd('/');
-            
-            return string.Format("{0}://{1}:{2}{3}", scheme, host, port, virtualPathRoot);
+            var virtualPathRoot = httpConfiguration.VirtualPathRoot;
+
+            var urb = new UriBuilder(scheme, host, int.Parse(port), virtualPathRoot);
+
+            return urb.Uri.AbsoluteUri.TrimEnd('/');
         }
 
         private static string GetHeaderValue(HttpRequestMessage request, string headerName)

--- a/Swashbuckle.Tests/Swagger/DefaultRootUrlResolverTests.cs
+++ b/Swashbuckle.Tests/Swagger/DefaultRootUrlResolverTests.cs
@@ -25,11 +25,26 @@
             var request = GetRequestFixtureFor(HttpMethod.Get, "http://tempuri.org:1234");
             request.Headers.Add("X-Forwarded-Proto", "https");
             request.Headers.Add("X-Forwarded-Host", "acmecorp.org");
-            request.Headers.Add("X-Forwarded-Port", "80");
+            request.Headers.Add("X-Forwarded-Port", "8080");
 
             var rootUrl = SwaggerDocsConfig.DefaultRootUrlResolver(request);
 
-            Assert.AreEqual("https://acmecorp.org:80", rootUrl);
+            Assert.AreEqual("https://acmecorp.org:8080", rootUrl);
+        }
+
+        [TestCase("http://tempuri.org", "http://tempuri.org")]
+        [TestCase("http://tempuri.org:80", "http://tempuri.org")]
+        [TestCase("http://tempuri.org:1234", "http://tempuri.org:1234")]
+        [TestCase("https://tempuri.org", "https://tempuri.org")]
+        [TestCase("https://tempuri.org:443", "https://tempuri.org")]
+        [TestCase("https://tempuri.org:1234", "https://tempuri.org:1234")]
+        public void It_provides_scheme_and_host_but_omits_default_port_from_request_uri(string requestedUri, string expectedUri)
+        {
+            var request = GetRequestFixtureFor(HttpMethod.Get, requestedUri);
+
+            var rootUrl = SwaggerDocsConfig.DefaultRootUrlResolver(request);
+
+            Assert.AreEqual(expectedUri, rootUrl);
         }
 
         private HttpRequestMessage GetRequestFixtureFor(HttpMethod method, string requestUri)


### PR DESCRIPTION
I've noticed that regardless of where the swagger documents are hosted, the URI of the swagger spec always includes the port, even if it uses the protocol default port i.e. 80 for http and 443 for https.

This update:
* alters the `DefaultRootUrlResolver` to use a `UriBuilder` handle the decision of including the port of not (instead of using string concatenation)
* adds new tests for omitting the port from the url when applicable

This will result in urls like `http://tempuri.org/swaggger/docs/1` instead of `http://tempuri.org:80/swaggger/docs/1`.