### PR TITLE
#960 Prevent SchemaFilter and DocumentFilter factories to be called multiple times.

### DIFF
--- a/Swashbuckle.Core/Application/SwaggerDocsConfig.cs
+++ b/Swashbuckle.Core/Application/SwaggerDocsConfig.cs
@@ -263,7 +263,7 @@ namespace Swashbuckle.Application
                 groupingKeySelector: _groupingKeySelector,
                 groupingKeyComparer: _groupingKeyComparer,
                 customSchemaMappings: _customSchemaMappings,
-                schemaFilters: _schemaFilters.Select(factory => factory()),
+                schemaFilters: _schemaFilters.Select(factory => factory()).ToList(),
                 modelFilters: modelFilters,
                 ignoreObsoleteProperties: _ignoreObsoleteProperties,
                 schemaIdSelector: _schemaIdSelector,
@@ -271,7 +271,7 @@ namespace Swashbuckle.Application
                 describeStringEnumsInCamelCase: _describeStringEnumsInCamelCase,
                 applyFiltersToAllSchemas: _applyFiltersToAllSchemas,
                 operationFilters: operationFilters,
-                documentFilters: _documentFilters.Select(factory => factory()),
+                documentFilters: _documentFilters.Select(factory => factory()).ToList(),
                 conflictingActionsResolver: _conflictingActionsResolver
             );
 


### PR DESCRIPTION
Prevent SchemaFilter and DocumentFilter factories to be called multiple times. Fixes issue #960 .

However if the intend was that the SchemaFilter and DocumentFilter are both constructed multiple times, this pull-request should be rejected.