### PR TITLE
Added option to merge duplicate schemas.

### DIFF
--- a/Swashbuckle.Core/Application/SwaggerDocsConfig.cs
+++ b/Swashbuckle.Core/Application/SwaggerDocsConfig.cs
@@ -32,6 +32,7 @@ namespace Swashbuckle.Application
         private bool _describeAllEnumsAsStrings;
         private bool _describeStringEnumsInCamelCase;
         private bool _applyFiltersToAllSchemas;
+        private bool _mergeDuplicateSchemas;
         private readonly IList<Func<IOperationFilter>> _operationFilters;
         private readonly IList<Func<IDocumentFilter>> _documentFilters;
         private readonly IList<Func<XPathDocument>> _xmlDocFactories;
@@ -53,6 +54,7 @@ namespace Swashbuckle.Application
             _describeAllEnumsAsStrings = false;
             _describeStringEnumsInCamelCase = false;
             _applyFiltersToAllSchemas = false;
+            _mergeDuplicateSchemas = false;
             _operationFilters = new List<Func<IOperationFilter>>();
             _documentFilters = new List<Func<IDocumentFilter>>();
             _xmlDocFactories = new List<Func<XPathDocument>>();
@@ -189,6 +191,11 @@ namespace Swashbuckle.Application
             _applyFiltersToAllSchemas = true;
         }
 
+        public void MergeDuplicateSchemas()
+        {
+            _mergeDuplicateSchemas = true;
+        }
+
         public void OperationFilter<TFilter>()
             where TFilter : IOperationFilter, new()
         {
@@ -270,6 +277,7 @@ namespace Swashbuckle.Application
                 describeAllEnumsAsStrings: _describeAllEnumsAsStrings,
                 describeStringEnumsInCamelCase: _describeStringEnumsInCamelCase,
                 applyFiltersToAllSchemas: _applyFiltersToAllSchemas,
+                mergeDuplicateSchemas: _mergeDuplicateSchemas,
                 operationFilters: operationFilters,
                 documentFilters: _documentFilters.Select(factory => factory()).ToList(),
                 conflictingActionsResolver: _conflictingActionsResolver

--- a/Swashbuckle.Core/Swagger/SwaggerGenerator.cs
+++ b/Swashbuckle.Core/Swagger/SwaggerGenerator.cs
@@ -39,7 +39,8 @@ namespace Swashbuckle.Swagger
                 _options.SchemaIdSelector,
                 _options.DescribeAllEnumsAsStrings,
                 _options.DescribeStringEnumsInCamelCase,
-                _options.ApplyFiltersToAllSchemas);
+                _options.ApplyFiltersToAllSchemas,
+                _options.MergeDuplicateSchemas);
 
             Info info;
             _apiVersions.TryGetValue(apiVersion, out info);

--- a/Swashbuckle.Core/Swagger/SwaggerGeneratorOptions.cs
+++ b/Swashbuckle.Core/Swagger/SwaggerGeneratorOptions.cs
@@ -22,6 +22,7 @@ namespace Swashbuckle.Swagger
             bool describeAllEnumsAsStrings = false,
             bool describeStringEnumsInCamelCase = false,
             bool applyFiltersToAllSchemas = false,
+            bool mergeDuplicateSchemas = false,
             IEnumerable<IOperationFilter> operationFilters = null,
             IEnumerable<IDocumentFilter> documentFilters = null,
             Func<IEnumerable<ApiDescription>, ApiDescription> conflictingActionsResolver = null
@@ -41,6 +42,7 @@ namespace Swashbuckle.Swagger
             DescribeAllEnumsAsStrings = describeAllEnumsAsStrings;
             DescribeStringEnumsInCamelCase = describeStringEnumsInCamelCase;
             ApplyFiltersToAllSchemas = applyFiltersToAllSchemas;
+            MergeDuplicateSchemas = mergeDuplicateSchemas;
             OperationFilters = operationFilters ?? new List<IOperationFilter>();
             DocumentFilters = documentFilters ?? new List<IDocumentFilter>();
             ConflictingActionsResolver = conflictingActionsResolver ?? DefaultConflictingActionsResolver;
@@ -73,6 +75,8 @@ namespace Swashbuckle.Swagger
         public bool DescribeStringEnumsInCamelCase { get; private set; }
 
         public bool ApplyFiltersToAllSchemas { get; private set; }
+
+        public bool MergeDuplicateSchemas { get; private set; }
 
         public IEnumerable<IOperationFilter> OperationFilters { get; private set; }
 


### PR DESCRIPTION
Looked through existing issues related to _Conflicting schemaIds_ error. None of them were relevant (i.e. we're not exposing generic types, we don't use a base controller, etc). The UseFullTypeNameInSchemaIds option also made no difference.
The error we're getting regarding the schema is for System.Guid (built in). Instead of spending a long time trying to track it down, a new option to merge duplicate schemas was added. As this is the default behaviour we'd like (i.e. we're happy to make the assumption that duplicates are in fact the same type).