### PR TITLE
Upgrades Swagger UI to v2.2.10

### DIFF
--- a/Swashbuckle.Dummy.Core/Controllers/FileDownloadController.cs
+++ b/Swashbuckle.Dummy.Core/Controllers/FileDownloadController.cs
@@ -5,14 +5,31 @@ using System.Web.Http;
 
 namespace Swashbuckle.Dummy.Controllers
 {
+    [RoutePrefix("FileDownload")]
     public class FileDownloadController : ApiController
     {
+        [HttpGet]
         public HttpResponseMessage GetFile()
         {
             var response = new HttpResponseMessage();
             var stream = new FileStream(@"c:\test.txt", FileMode.Open);
             response.Content = new StreamContent(stream);
             response.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+            return response;
+        }
+
+        [HttpGet]
+        [Route("filename")]
+        public HttpResponseMessage GetFileWithFilename()
+        {
+            var response = new HttpResponseMessage();
+            var stream = new FileStream(@"c:\test.txt", FileMode.Open);
+            response.Content = new StreamContent(stream);
+            response.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+            response.Content.Headers.ContentDisposition = new ContentDispositionHeaderValue("attachment")
+            {
+                FileName = "test.txt"
+            };
             return response;
         }
     }


### PR DESCRIPTION
We hit an error for download files with content dispositions due to incorrect use of the `URL.createObjectURL` function when using blobs in the swagger ui. This is fixed in newer versions of swagger ui, but Swashbuckle use an older version.

This PR upgrades the swagger-ui submodule to the latest release (v2.2.10) and additionally adds an controller endpoint testing verifying the issue with swagger-ui.

I couldn't find any way to verify/test swagger-ui except the override controls as tests and manually testing the dummy selfhost. But all looks good to me and I couldn't find any broken features (nor should there be any breaking changes in the swagger-ui package).

Let me know if there's anything else you need from me.