### PR TITLE
fix for missing mapping with custom javascript

### DIFF
--- a/Swashbuckle.Core/SwaggerUi/CustomAssets/index.html
+++ b/Swashbuckle.Core/SwaggerUi/CustomAssets/index.html
@@ -34,6 +34,11 @@
 
   <script type="text/javascript">
     $(function () {
+      
+      //if cache is false, jQuery's getScript function adds a timestamp as postfix to all script URLs, which causes a MappingNotFound exception.
+      $.ajaxSetup({
+        cache: true
+      });
 
       // Get Swashbuckle config into JavaScript
       function arrayFrom(configString) {


### PR DESCRIPTION
If cache is false, jQuery's `getScript` function adds a timestamp as postfix to all script URLs, which causes a `MappingNotFound` exception when fetching the resource.

Would like other proposals to fix this. It's on a default ASP .NET OWIN Web API 2 project with Swashbuckle installed and custom JavaScript injected. Upon loading, it gives a 404 for the script in the UI, but if the timestamp is removed, there is no 404.