### PR TITLE
#1024 missing RequestMessage

### DIFF
--- a/Swashbuckle.Core/Application/SwaggerUiHandler.cs
+++ b/Swashbuckle.Core/Application/SwaggerUiHandler.cs
@@ -27,7 +27,7 @@ namespace Swashbuckle.Application
             {
                 var webAsset = swaggerUiProvider.GetAsset(rootUrl, assetPath);
                 var content = ContentFor(webAsset);
-                return TaskFor(new HttpResponseMessage { Content = content });
+                return TaskFor(new HttpResponseMessage { Content = content, RequestMessage = request });
             }
             catch (AssetNotFound ex)
             {


### PR DESCRIPTION
If other services will use custom "HttpMessageHandler" to modify responses they can receive null reference error if will try to access "RequestMessage".