### PR TITLE
Support for enum names + values (x-names, x-values)

### DIFF
--- a/Swashbuckle.Core/Swagger/SchemaRegistry.cs
+++ b/Swashbuckle.Core/Swagger/SchemaRegistry.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
 using System.Dynamic;
 using System.Linq;
 using System.Net.Http;
@@ -175,26 +176,49 @@ namespace Swashbuckle.Swagger
             var stringEnumConverter = primitiveContract.Converter as StringEnumConverter
                 ?? _jsonSerializerSettings.Converters.OfType<StringEnumConverter>().FirstOrDefault();
 
-            if (_describeAllEnumsAsStrings || stringEnumConverter != null)
-            {
-                var camelCase = _describeStringEnumsInCamelCase
+            var camelCase = _describeStringEnumsInCamelCase
                     || (stringEnumConverter != null && stringEnumConverter.CamelCaseText);
 
-                return new Schema
-                {
-                    type = "string",
-                    @enum = camelCase
-                        ? type.GetEnumNamesForSerialization().Select(name => name.ToCamelCase()).ToArray()
-                        : type.GetEnumNamesForSerialization()
-                };
+            string[] names = type.GetEnumNamesForSerialization().ToArray();
+
+            if (camelCase)
+            {
+                names = names.Select(name => name.ToCamelCase()).ToArray();
             }
-            
-            return new Schema
+
+            var textEnumSchema = new Schema
+            {
+                type = "string",
+                @enum = names
+            };
+
+            var values = type.GetEnumValues().Cast<int>().ToArray();
+
+            var intEnumSchema = new Schema
             {
                 type = "integer",
                 format = "int32",
-                @enum = type.GetEnumValues().Cast<object>().ToArray()
+                @enum = values.Cast<object>().ToArray()
             };
+
+            var namesAndValuesAreSame = textEnumSchema.@enum == intEnumSchema.@enum.Cast<string>();
+
+            if (_describeAllEnumsAsStrings || stringEnumConverter != null)
+            {
+                if (!namesAndValuesAreSame)
+                {
+                    textEnumSchema.vendorExtensions.Add("x-values", intEnumSchema.@enum);
+                }
+
+                return textEnumSchema;
+            }
+
+            if (!namesAndValuesAreSame)
+            {
+                intEnumSchema.vendorExtensions.Add("x-names", textEnumSchema.@enum);
+            }
+            
+            return intEnumSchema;
         }
 
         private Schema CreateDictionarySchema(JsonDictionaryContract dictionaryContract)


### PR DESCRIPTION
I added support for enum keys and values as vendor extension elements. I needed them for my TypeScript Autorest code generation project. https://github.com/agoda-com/autorest

It should seamlessly extend both string and int enums. 

"parameters": [
{
"name": "value",
"in": "query",
"required": true,
"type": "integer",
"format": "int32",
"enum": [
  0,
  1,
  2,
  3
],
"x-names": [
  "OneFish",
  "TwoFish",
  "RedFish",
  "BlueFish"
],
"x-type-dotnet": "Swashbuckle.Dummy.Types.PrimitiveEnum",
"x-nullable": true
}

and 

"parameters": [
{
"name": "value",
"in": "query",
"required": true,
"type": "string",
"enum": [
  "OneFish",
  "TwoFish",
  "RedFish",
  "BlueFish"
],
"x-values": [
  0,
  1,
  2,
  3
],
"x-type-dotnet": "Swashbuckle.Dummy.Types.PrimitiveEnum",
"x-nullable": true
}