### PR TITLE
Newtonsoft.Json package updated to v7.0.1, issue #1041 fixed.

### DIFF
--- a/Swashbuckle.Core/Swagger/SchemaRegistry.cs
+++ b/Swashbuckle.Core/Swagger/SchemaRegistry.cs
@@ -188,7 +188,7 @@ namespace Swashbuckle.Swagger
                         : type.GetEnumNamesForSerialization()
                 };
             }
-            
+
             return new Schema
             {
                 type = "integer",
@@ -208,7 +208,7 @@ namespace Swashbuckle.Swagger
                 {
                     type = "object",
                     properties = Enum.GetNames(keyType).ToDictionary(
-                        (name) => dictionaryContract.PropertyNameResolver(name),
+                        (name) => dictionaryContract.DictionaryKeyResolver(name),
                         (name) => CreateInlineSchema(valueType)
                     )
                 };
@@ -259,7 +259,7 @@ namespace Swashbuckle.Swagger
         {
             if (!_workItems.ContainsKey(type))
             {
-                var schemaId = _schemaIdSelector(type); 
+                var schemaId = _schemaIdSelector(type);
                 if (_workItems.Any(entry => entry.Value.SchemaId == schemaId))
                 {
                     var conflictingType = _workItems.First(entry => entry.Value.SchemaId == schemaId).Key;

--- a/Swashbuckle.Core/Swashbuckle.Core.csproj
+++ b/Swashbuckle.Core/Swashbuckle.Core.csproj
@@ -43,8 +43,8 @@
   </PropertyGroup>
   <PropertyGroup />
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.4.5.6\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
@@ -124,6 +124,7 @@
     <Content Include="Swashbuckle.Core.nuspec">
       <SubType>Designer</SubType>
     </Content>
+    <None Include="app.config" />
     <None Include="packages.config" />
     <None Include="Swashbuckle.Core.snk" />
   </ItemGroup>

--- a/Swashbuckle.Core/Swashbuckle.Core.nuspec
+++ b/Swashbuckle.Core/Swashbuckle.Core.nuspec
@@ -14,6 +14,7 @@
     <tags>Swagger SwaggerUi Documentation Discovery Help WebApi AspNet AspNetWebApi Docs SelfHost OWIN</tags>
     <dependencies>
       <dependency id="Microsoft.AspNet.WebApi.Core" version="4.0.20710" />
+      <dependency id="Newtonsoft.Json" version="7.0.1" />
     </dependencies>
   </metadata>
 </package>

--- a/Swashbuckle.Core/app.config
+++ b/Swashbuckle.Core/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Swashbuckle.Core/packages.config
+++ b/Swashbuckle.Core/packages.config
@@ -3,5 +3,5 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="4.0.20710.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.WebApi.Core" version="4.0.20710.0" targetFramework="net40" />
   <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net40" />
-  <package id="Newtonsoft.Json" version="4.5.6" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net40" />
 </packages>

--- a/Swashbuckle.Dummy.Core/Swashbuckle.Dummy.Core.csproj
+++ b/Swashbuckle.Dummy.Core/Swashbuckle.Dummy.Core.csproj
@@ -36,9 +36,8 @@
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/Swashbuckle.Dummy.Core/app.config
+++ b/Swashbuckle.Dummy.Core/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/Swashbuckle.Dummy.Core/packages.config
+++ b/Swashbuckle.Dummy.Core/packages.config
@@ -4,5 +4,5 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Cors" version="5.0.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
 </packages>

--- a/Swashbuckle.Dummy.SelfHost/Swashbuckle.Dummy.SelfHost.csproj
+++ b/Swashbuckle.Dummy.SelfHost/Swashbuckle.Dummy.SelfHost.csproj
@@ -34,9 +34,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Swashbuckle.Dummy.SelfHost/app.config
+++ b/Swashbuckle.Dummy.SelfHost/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/Swashbuckle.Dummy.SelfHost/packages.config
+++ b/Swashbuckle.Dummy.SelfHost/packages.config
@@ -3,5 +3,5 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.SelfHost" version="5.2.2" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
 </packages>

--- a/Swashbuckle.Dummy.WebHost/Swashbuckle.Dummy.WebHost.csproj
+++ b/Swashbuckle.Dummy.WebHost/Swashbuckle.Dummy.WebHost.csproj
@@ -42,9 +42,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/Swashbuckle.Dummy.WebHost/Web.config
+++ b/Swashbuckle.Dummy.WebHost/Web.config
@@ -22,7 +22,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/Swashbuckle.Dummy.WebHost/packages.config
+++ b/Swashbuckle.Dummy.WebHost/packages.config
@@ -3,5 +3,5 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.2" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
 </packages>

--- a/Swashbuckle.Tests/Swashbuckle.Tests.csproj
+++ b/Swashbuckle.Tests/Swashbuckle.Tests.csproj
@@ -54,9 +54,8 @@
     <Reference Include="Moq">
       <HintPath>..\packages\Moq.4.0.10827\lib\NET40\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>

--- a/Swashbuckle.Tests/app.config
+++ b/Swashbuckle.Tests/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/Swashbuckle.Tests/packages.config
+++ b/Swashbuckle.Tests/packages.config
@@ -7,7 +7,7 @@
   <package id="Microsoft.Owin.Hosting" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.Testing" version="3.0.1" targetFramework="net45" />
   <package id="Moq" version="4.0.10827" targetFramework="net4" />
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.2" targetFramework="net4" />
   <package id="Owin" version="1.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Newtonsoft.Json marked `JsonDictionaryContract.PropertyNameResolver` as obsolete and added `JsonDictionaryContract.DictionaryKeyResolver` on v7.0.1. They removed `JsonDictionaryContract.PropertyNameResolver` on v10.0.1.

I've updated Newtonsoft.Json to v7.0.1 and changed `JsonDictionaryContract.PropertyNameResolver` usage to `JsonDictionaryContract.DictionaryKeyResolver` and also added Newtonsoft.Json >= v7.0.1 dependency to Swashbuckle.Core package.