### PR TITLE
Provide example data on definition properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,35 @@ Swashbuckle will automatically create a "success" response for each operation ba
 /// <response code="400">Username already in use</response>
 public int Create(Account account)
 ```
+#### Response Models ####
+
+Swashbuckle will automatically generate the right model definition based on the response type; but you can customise this using an attribute, and using XMLComments you can provide more contextual information:
+
+```csharp
+public class Account
+{
+    /// <summary>
+    /// The ID for Accounts is 5 digits long.
+    /// </summary>
+    /// <example>78312</example>
+    public int AccountId { get; set; }
+
+    /// <summary>
+    /// Uniquely identifies the account
+    /// </summary>
+    /// <example>TestUser</example>
+    public string UserName { get; set; }
+
+    /// <summary>
+    /// For authentication
+    /// </summary>
+    public int UserPassword { get; set; }
+}
+
+[SwaggerResponse( HttpStatusCode.OK, Description = "Returns an array of accounts", Type = typeof( IEnumerable<Account> ) )]
+public int GetAccounts()
+```
+
 ### Working Around Swagger 2.0 Constraints ###
 
 In contrast to Web API, Swagger 2.0 does not include the query string component when mapping a URL to an action. As a result, Swashbuckle will raise an exception if it encounters multiple actions with the same path (sans query string) and HTTP method. You can workaround this by providing a custom strategy to pick a winner or merge the descriptions for the purposes of the Swagger docs 

--- a/Swashbuckle.Core/Swagger/XmlComments/ApplyXmlTypeComments.cs
+++ b/Swashbuckle.Core/Swagger/XmlComments/ApplyXmlTypeComments.cs
@@ -7,6 +7,7 @@ namespace Swashbuckle.Swagger.XmlComments
     {
         private const string MemberXPath = "/doc/members/member[@name='{0}']";
         private const string SummaryTag = "summary";
+        private const string ExampleTag = "example";
 
         private readonly XPathDocument _xmlDoc;
 
@@ -31,9 +32,13 @@ namespace Swashbuckle.Swagger.XmlComments
 
             if (typeNode != null)
             {
-                var summaryNode = typeNode.SelectSingleNode(SummaryTag);
-                if (summaryNode != null)
+                var summaryNode = typeNode.SelectSingleNode( SummaryTag );
+                if( summaryNode != null )
                     model.description = summaryNode.ExtractContent();
+
+                var exampleNode = typeNode.SelectSingleNode( ExampleTag );
+                if( exampleNode != null )
+                    model.example = exampleNode.ExtractContent();
             }
 
             if (model.properties != null)
@@ -60,6 +65,12 @@ namespace Swashbuckle.Swagger.XmlComments
             if (propSummaryNode != null)
             {
                 propertySchema.description = propSummaryNode.ExtractContent();
+            }
+
+            var propExampleNode = propertyNode.SelectSingleNode( ExampleTag );
+            if( propExampleNode != null )
+            {
+                propertySchema.example = propExampleNode.ExtractContent();
             }
         }
     }

--- a/Swashbuckle.Dummy.Core/Controllers/XmlAnnotatedController.cs
+++ b/Swashbuckle.Dummy.Core/Controllers/XmlAnnotatedController.cs
@@ -110,16 +110,19 @@ namespace Swashbuckle.Dummy.Controllers
         /// <summary>
         /// The ID for Accounts is 5 digits long.
         /// </summary>
+        /// <example>78312</example>
         public virtual int AccountID { get; set; }
 
         /// <summary>
         /// Uniquely identifies the account
         /// </summary>
+        /// <example>TestUser</example>
         public string Username { get; set; }
 
         /// <summary>
         /// For authentication
         /// </summary>
+        /// <example>TestPassword</example>
         public string Password { get; set; }
 
         public AccountPreferences Preferences { get; set; }

--- a/Swashbuckle.Tests/Swagger/XmlCommentsTests.cs
+++ b/Swashbuckle.Tests/Swagger/XmlCommentsTests.cs
@@ -110,6 +110,24 @@ namespace Swashbuckle.Tests.Swagger
         }
 
         [Test]
+        public void It_documents_schema_properties_from_property_example_tags()
+        {
+            var swagger = GetContent<JObject>( "http://tempuri.org/swagger/docs/v1" );
+
+            var passwordAccountId = swagger[ "definitions" ][ "Account" ][ "properties" ][ "AccountID" ];
+            Assert.IsNotNull( passwordAccountId[ "example" ] );
+            Assert.AreEqual( "78312", passwordAccountId[ "example" ].ToString() );
+
+            var usernameProperty = swagger[ "definitions" ][ "Account" ][ "properties" ][ "Username" ];
+            Assert.IsNotNull( usernameProperty[ "example" ] );
+            Assert.AreEqual( "TestUser", usernameProperty[ "example" ].ToString() );
+
+            var passwordProperty = swagger[ "definitions" ][ "Account" ][ "properties" ][ "Password" ];
+            Assert.IsNotNull( passwordProperty[ "example" ] );
+            Assert.AreEqual( "TestPassword", passwordProperty[ "example" ].ToString() );
+        }
+
+        [Test]
         public void It_documents_schema_properties_including_property_summary_tags_from_base_classes()
         {
             var swagger = GetContent<JObject>("http://tempuri.org/swagger/docs/v1");


### PR DESCRIPTION
By decorating a definition property with an <example> xml comment, you will get proper 'live' sample data in the example section of a response.

Hope this is okay, not done many PRs before :-)