### PR TITLE
Add an issue template with a link to stackoverflow

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,10 @@
 <!--- 
 
-PLEASE POST YOUR QUESTIONS ON STACKOVERFLOW:
+If you have questions about how to use swashbuckle, please read the wiki page or ask on Stack Overflow.
 https://stackoverflow.com/questions/tagged/swashbuckle
+
+There are many questions on Stack Overflow with the swashbuckle tag.
+
+GitHub issues are only for reporting bugs, not questions or help.
 
 --->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,6 @@
+<!--- 
+
+PLEASE POST YOUR QUESTIONS ON STACKOVERFLOW:
+https://stackoverflow.com/questions/tagged/swashbuckle
+
+--->


### PR DESCRIPTION
This should point people to ask questions on stackoverflow
... and stop the excessive Q/A on the internal issues