### PR TITLE
Use Additional API Explorer Metadata 

### DIFF
--- a/Swashbuckle.Core/Swagger/ApiDescriptionExtensions.cs
+++ b/Swashbuckle.Core/Swagger/ApiDescriptionExtensions.cs
@@ -17,14 +17,14 @@ namespace Swashbuckle.Swagger
         public static IEnumerable<string> Consumes(this ApiDescription apiDescription)
         {
             return apiDescription.SupportedRequestBodyFormatters
-                .SelectMany(formatter => formatter.SupportedMediaTypes.Select(mediaType => mediaType.MediaType))
+                .SelectMany(formatter => formatter.SupportedMediaTypes.Select(mediaType => mediaType.ToString()))
                 .Distinct();
         }
 
         public static IEnumerable<string> Produces(this ApiDescription apiDescription)
         {
             return apiDescription.SupportedResponseFormatters
-                .SelectMany(formatter => formatter.SupportedMediaTypes.Select(mediaType => mediaType.MediaType))
+                .SelectMany(formatter => formatter.SupportedMediaTypes.Select(mediaType => mediaType.ToString()))
                 .Distinct();
         }
 

--- a/Swashbuckle.Core/Swagger/SwaggerGenerator.cs
+++ b/Swashbuckle.Core/Swagger/SwaggerGenerator.cs
@@ -188,13 +188,17 @@ namespace Swashbuckle.Swagger
             }
 
             parameter.required = location == "path" || !paramDesc.ParameterDescriptor.IsOptional;
-            parameter.@default = paramDesc.ParameterDescriptor.DefaultValue;
+            parameter.description = paramDesc.Documentation;
 
             var schema = schemaRegistry.GetOrRegister(paramDesc.ParameterDescriptor.ParameterType);
+
             if (parameter.@in == "body")
                 parameter.schema = schema;
             else
                 parameter.PopulateFrom(schema);
+
+            if (paramDesc.ParameterDescriptor.DefaultValue != null)
+                parameter.@default = paramDesc.ParameterDescriptor.DefaultValue;
 
             return parameter;
         }

--- a/Swashbuckle.Core/Swagger/XmlComments/ApplyXmlActionComments.cs
+++ b/Swashbuckle.Core/Swagger/XmlComments/ApplyXmlActionComments.cs
@@ -69,8 +69,14 @@ namespace Swashbuckle.Swagger.XmlComments
                 if (actionParameter == null) continue;
 
                 var paramNode = methodNode.SelectSingleNode(string.Format(ParamXPath, actionParameter.Name));
+
                 if (paramNode != null)
-                    parameter.description = paramNode.ExtractContent();
+                {
+                    var description = paramNode.ExtractContent();
+
+                    if (!string.IsNullOrEmpty(description))
+                        parameter.description = description;
+                }
             }
         }
 

--- a/Swashbuckle.Dummy.Core/Controllers/XmlAnnotatedController.cs
+++ b/Swashbuckle.Dummy.Core/Controllers/XmlAnnotatedController.cs
@@ -87,6 +87,13 @@ namespace Swashbuckle.Dummy.Controllers
         {
             throw new NotImplementedException();
         }
+
+        [HttpGet] 
+        [Route("GetById")] 
+        public void GetById(string id = "123456")
+        {
+            throw new NotImplementedException();
+        }
     }
 
     public class Page

--- a/Swashbuckle.Tests/Swagger/XmlCommentsTests.cs
+++ b/Swashbuckle.Tests/Swagger/XmlCommentsTests.cs
@@ -224,6 +224,21 @@ namespace Swashbuckle.Tests.Swagger
             Assert.IsNotNull(responsesProperty["500"]);
         }
 
+        [Test]
+        public void It_documents_schema_default_parameters()
+        {
+            var swagger = GetContent<JObject>( "http://tempuri.org/swagger/docs/v1" );
+
+            var parameters = swagger["paths"]["/xmlannotated/GetById"]["get"]["parameters"];
+            Assert.IsNotNull( parameters );
+
+            Assert.IsNotNull( parameters.First["required"] );
+            Assert.AreEqual( "False", parameters.First["required"].ToString() );
+
+            Assert.IsNotNull( parameters.First["default"] );
+            Assert.AreEqual( "123456", parameters.First["default"].ToString() );
+        }
+
         private void IncludeXmlComments(SwaggerDocsConfig config)
         {
             config.IncludeXmlComments(String.Format(@"{0}\XmlComments.xml", AppDomain.CurrentDomain.BaseDirectory));


### PR DESCRIPTION
Honors additional API explorer metadata, when available.  The information is mapped from:

* ApiParameterDescription.ParameterDescriptor.DefaultValue 
* ApiParameterDescription.Documentation
* The complete set of media type information is also utilized

This will negate the requirement to use IOperationFilter when API explorers provide this information.  Resolves #1101. Resolves #1133.