### PR TITLE
Closes #1197: Derived class is not using the base class schema filter

### DIFF
--- a/Swashbuckle.Core/Swagger/Annotations/ApplySwaggerSchemaFilterAttributes.cs
+++ b/Swashbuckle.Core/Swagger/Annotations/ApplySwaggerSchemaFilterAttributes.cs
@@ -6,11 +6,18 @@ namespace Swashbuckle.Swagger.Annotations
 {
     public class ApplySwaggerSchemaFilterAttributes : ISchemaFilter
     {
+        private IEnumerable<SwaggerSchemaFilterAttribute> Attributes(Type type)
+        {
+            var attributes = type.GetCustomAttributes(true).OfType<SwaggerSchemaFilterAttribute>();
+            if (!attributes.Any() && type.BaseType != null)
+                return Attributes(type.BaseType);
+            else
+                return attributes;
+        }
+
         public void Apply(Schema schema, SchemaRegistry schemaRegistry, Type type)
         {
-            var attributes = type.GetCustomAttributes(false).OfType<SwaggerSchemaFilterAttribute>();
-
-            foreach (var attribute in attributes)
+            foreach (var attribute in Attributes(type))
             {
                 var filter = (ISchemaFilter)Activator.CreateInstance(attribute.FilterType);
                 filter.Apply(schema, schemaRegistry, type);

--- a/Swashbuckle.Core/Swagger/Annotations/ApplySwaggerSchemaFilterAttributes.cs
+++ b/Swashbuckle.Core/Swagger/Annotations/ApplySwaggerSchemaFilterAttributes.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Web.Http.Description;
 


### PR DESCRIPTION
This is the smallest fix possible to close #1197.

This fixes the same bug as #445 but this is simpler and can hopefully be merged right away.

Credit goes to @heldersepu, I'm opening this PR with his permission.