### PR TITLE
Add RoutePrefix for Swagger UI and Swagger docs.

### DIFF
--- a/Swashbuckle.Core/Application/SwaggerDocsConfig.cs
+++ b/Swashbuckle.Core/Application/SwaggerDocsConfig.cs
@@ -40,6 +40,9 @@ namespace Swashbuckle.Application
 
         private Func<ISwaggerProvider, ISwaggerProvider> _customProviderFactory;
 
+        // Routing Prefix to the Swagger Docs
+        public string RoutePrefix { set; get; }
+
         public SwaggerDocsConfig()
         {
             _versionInfoBuilder = new VersionInfoBuilder();

--- a/Swashbuckle.Core/Application/SwaggerUiConfig.cs
+++ b/Swashbuckle.Core/Application/SwaggerUiConfig.cs
@@ -14,6 +14,10 @@ namespace Swashbuckle.Application
         private readonly Dictionary<string, string> _templateParams;
         private readonly Func<HttpRequestMessage, string> _rootUrlResolver;
 
+        // Routing Prefix to the Swagger UI
+        public string RoutePrefix { set; get; }
+
+
         public SwaggerUiConfig(IEnumerable<string> discoveryPaths, Func<HttpRequestMessage, string> rootUrlResolver)
         {
             _pathToAssetMap = new Dictionary<string, EmbeddedAssetDescriptor>();
@@ -34,8 +38,8 @@ namespace Swashbuckle.Application
                 { "%(OAuth2AppName)", "" },
                 { "%(OAuth2ScopeSeperator)", " " },
                 { "%(OAuth2AdditionalQueryStringParams)", "{}" },
-				{ "%(ApiKeyName)", "api_key" },
-				{ "%(ApiKeyIn)", "query" }
+                { "%(ApiKeyName)", "api_key" },
+                { "%(ApiKeyIn)", "query" }
             };
             _rootUrlResolver = rootUrlResolver;
 
@@ -133,10 +137,11 @@ namespace Swashbuckle.Application
                 _templateParams["%(OAuth2AdditionalQueryStringParams)"] = JsonConvert.SerializeObject(additionalQueryStringParams);
         }
 
-		public void EnableApiKeySupport(string name, string apiKeyIn) {
-			_templateParams["%(ApiKeyName)"] = name;
-			_templateParams["%(ApiKeyIn)"] = apiKeyIn;
-		}
+        public void EnableApiKeySupport(string name, string apiKeyIn)
+        {
+            _templateParams["%(ApiKeyName)"] = name;
+            _templateParams["%(ApiKeyIn)"] = apiKeyIn;
+        }
 
         internal IAssetProvider GetSwaggerUiProvider()
         {


### PR DESCRIPTION
Add RoutePrefix for Swagger UI and Swagger docs. This change support the scenario that there are multiple swaggers used with ASP.NET web API projects as different Areas in the ASP.NET web MVC project.