### PR TITLE
Endpoint /swagger/docs/latest will always return the latest version 

### DIFF
--- a/Swashbuckle.Core/Swagger/SwaggerGenerator.cs
+++ b/Swashbuckle.Core/Swagger/SwaggerGenerator.cs
@@ -43,12 +43,12 @@ namespace Swashbuckle.Swagger
                 _options.ApplyFiltersToAllSchemas);
 
             Info info;
-			if (apiVersion.ToLower() == "latest")
-				info = _apiVersions.OrderByDescending(x => x.Value.version).First().Value;
-			else
-				_apiVersions.TryGetValue(apiVersion, out info);
+            if (apiVersion.ToLower() == "latest")
+                info = _apiVersions.OrderByDescending(x => x.Value.version).First().Value;
+            else
+                _apiVersions.TryGetValue(apiVersion, out info);
 
-			if (info == null)
+            if (info == null)
                 throw new UnknownApiVersion(apiVersion);
 
             var paths = GetApiDescriptionsFor(apiVersion)

--- a/Swashbuckle.Core/Swagger/SwaggerGenerator.cs
+++ b/Swashbuckle.Core/Swagger/SwaggerGenerator.cs
@@ -43,8 +43,12 @@ namespace Swashbuckle.Swagger
                 _options.ApplyFiltersToAllSchemas);
 
             Info info;
-            _apiVersions.TryGetValue(apiVersion, out info);
-            if (info == null)
+			if (apiVersion.ToLower() == "latest")
+				info = _apiVersions.OrderByDescending(x => x.Value.version).First().Value;
+			else
+				_apiVersions.TryGetValue(apiVersion, out info);
+
+			if (info == null)
                 throw new UnknownApiVersion(apiVersion);
 
             var paths = GetApiDescriptionsFor(apiVersion)


### PR DESCRIPTION
Endpoint /swagger/docs/latest will always return the latest version of the swagger document.  This is very useful for CI solutions and solutions where version numbers are changing rapidly

Solves #1255
