### PR TITLE
Fix DefaultRootUrlResolver to handle X-Forwarded-Host containing port number

### DIFF
--- a/Swashbuckle.Core/Application/SwaggerDocsConfig.cs
+++ b/Swashbuckle.Core/Application/SwaggerDocsConfig.cs
@@ -311,7 +311,9 @@ namespace Swashbuckle.Application
             var httpConfiguration = request.GetConfiguration();
             var virtualPathRoot = httpConfiguration.VirtualPathRoot;
 
-            var urb = new UriBuilder(scheme, host, int.Parse(port), prefix + virtualPathRoot);
+            var uri = new Uri(host);
+
+            var urb = new UriBuilder(scheme, uri.Host, int.Parse(port), prefix + virtualPathRoot);
 
             return urb.Uri.AbsoluteUri.TrimEnd('/');
         }


### PR DESCRIPTION
Some reverse proxies add port number to the X-Forwarded-Host. The fix is to handler such scenarios to get the hostname only. The current code throws the following exception when the host contains port number. e.g 50.1.0.5:9002

Exception message : {"Invalid URI: The hostname could not be parsed."}
at System.Uri.CreateThis(String uri, Boolean dontEscape, UriKind uriKind)
at System.Uri..ctor(String uriString)
at System.UriBuilder.get_Uri()
at Swashbuckle.Application.SwaggerDocsConfig.DefaultRootUrlResolver(HttpRequestMessage request)\r\n