### PR TITLE
Added support for TimeSpan

### DIFF
--- a/Swashbuckle.Core/Swagger/SchemaRegistry.cs
+++ b/Swashbuckle.Core/Swagger/SchemaRegistry.cs
@@ -1,18 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Dynamic;
 using System.Linq;
-using System.Net.Http;
-using System.Reflection;
-using System.Runtime.Serialization;
-using System.Text;
-using System.Web.Http;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using Newtonsoft.Json.Converters;
-using System.Net.Http.Formatting;
 
 namespace Swashbuckle.Swagger
 {
@@ -30,7 +21,7 @@ namespace Swashbuckle.Swagger
 
         private readonly IContractResolver _contractResolver;
 
-        private IDictionary<Type, WorkItem> _workItems;
+        private readonly IDictionary<Type, WorkItem> _workItems;
         private class WorkItem
         {
             public string SchemaId;
@@ -163,6 +154,8 @@ namespace Swashbuckle.Swagger
                 case "System.DateTime":
                 case "System.DateTimeOffset":
                     return new Schema { type = "string", format = "date-time" };
+                case "System.TimeSpan":
+                    return new Schema { type = "string", format = "time-span" };
                 case "System.Guid":
                     return new Schema { type = "string", format = "uuid", example = Guid.Empty };
                 default:

--- a/Swashbuckle.Tests/Swagger/SchemaTests.cs
+++ b/Swashbuckle.Tests/Swagger/SchemaTests.cs
@@ -1,12 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Net.Http;
 using System.Linq;
 using NUnit.Framework;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Converters;
 using Swashbuckle.Dummy.Controllers;
-using Swashbuckle.Application;
 using Swashbuckle.Swagger;
 using Swashbuckle.Dummy.SwaggerExtensions;
 using Swashbuckle.Dummy.Types;
@@ -108,7 +106,7 @@ namespace Swashbuckle.Tests.Swagger
 
             var expected = JObject.FromObject(new {
                 PaymentWithMetadata = new {
-                    required = new string[] { "Amount", "CardNumber", "ExpMonth", "ExpYear" },
+                    required = new[] { "Amount", "CardNumber", "ExpMonth", "ExpYear" },
                     type = "object",
                     properties = new {
                         Amount = new {
@@ -155,7 +153,7 @@ namespace Swashbuckle.Tests.Swagger
                 {
                     Payment = new
                     {
-                        required = new string[] { "Amount", "CardNumber", "ExpMonth", "ExpYear" },
+                        required = new[] { "Amount", "CardNumber", "ExpMonth", "ExpYear" },
                         type = "object",
                         properties = new
                         {
@@ -401,7 +399,7 @@ namespace Swashbuckle.Tests.Swagger
         [TestCase("EchoDecimal", typeof(decimal), "number", "double", "System.Decimal", false)]
         [TestCase("EchoDateTime", typeof(DateTime), "string", "date-time", "System.DateTime", false)]
         [TestCase("EchoDateTimeOffset", typeof(DateTimeOffset), "string", "date-time", "System.DateTimeOffset", false)]
-        [TestCase("EchoTimeSpan", typeof(TimeSpan), "string", null, "System.TimeSpan", false)]
+        [TestCase("EchoTimeSpan", typeof(TimeSpan), "string", "time-span", "System.TimeSpan", false)]
         [TestCase("EchoEnum", typeof(PrimitiveEnum), "integer", "int32", "Swashbuckle.Dummy.Types.PrimitiveEnum", false)]
         [TestCase("EchoEnum", typeof(PrimitiveEnum), "string", null, "Swashbuckle.Dummy.Types.PrimitiveEnum", false)]
         [TestCase("EchoChar", typeof(char), "string", null, "System.Char", false)]
@@ -419,7 +417,7 @@ namespace Swashbuckle.Tests.Swagger
         [TestCase("EchoNullableDecimal", typeof(decimal?), "number", "double", "System.Decimal", true)]
         [TestCase("EchoNullableDateTime", typeof(DateTime?), "string", "date-time", "System.DateTime", true)]
         [TestCase("EchoNullableDateTimeOffset", typeof(DateTimeOffset?), "string", "date-time", "System.DateTimeOffset", true)]
-        [TestCase("EchoNullableTimeSpan", typeof(TimeSpan?), "string", null, "System.TimeSpan", true)]
+        [TestCase("EchoNullableTimeSpan", typeof(TimeSpan?), "string", "time-span", "System.TimeSpan", true)]
         [TestCase("EchoNullableEnum", typeof(PrimitiveEnum?), "integer", "int32", "Swashbuckle.Dummy.Types.PrimitiveEnum", true)]
         [TestCase("EchoNullableEnum", typeof(PrimitiveEnum?), "string", null, "Swashbuckle.Dummy.Types.PrimitiveEnum", true)]
         [TestCase("EchoNullableChar", typeof(char?), "string", null, "System.Char", true)]
@@ -495,7 +493,7 @@ namespace Swashbuckle.Tests.Swagger
         [TestCase("EchoDecimal", typeof(decimal), "number", "double", "System.Decimal", false)]
         [TestCase("EchoDateTime", typeof(DateTime), "string", "date-time", "System.DateTime", false)]
         [TestCase("EchoDateTimeOffset", typeof(DateTimeOffset), "string", "date-time", "System.DateTimeOffset", false)]
-        [TestCase("EchoTimeSpan", typeof(TimeSpan), "string", null, "System.TimeSpan", false)]
+        [TestCase("EchoTimeSpan", typeof(TimeSpan), "string", "time-span", "System.TimeSpan", false)]
         [TestCase("EchoEnum", typeof(PrimitiveEnum), "integer", "int32", "Swashbuckle.Dummy.Types.PrimitiveEnum", false)]
         [TestCase("EchoEnum", typeof(PrimitiveEnum), "string", null, "Swashbuckle.Dummy.Types.PrimitiveEnum", false)]
         [TestCase("EchoChar", typeof(char), "string", null, "System.Char", false)]
@@ -513,7 +511,7 @@ namespace Swashbuckle.Tests.Swagger
         [TestCase("EchoNullableDecimal", typeof(decimal?), "number", "double", "System.Decimal", true)]
         [TestCase("EchoNullableDateTime", typeof(DateTime?), "string", "date-time", "System.DateTime", true)]
         [TestCase("EchoNullableDateTimeOffset", typeof(DateTimeOffset?), "string", "date-time", "System.DateTimeOffset", true)]
-        [TestCase("EchoNullableTimeSpan", typeof(TimeSpan?), "string", null, "System.TimeSpan", true)]
+        [TestCase("EchoNullableTimeSpan", typeof(TimeSpan?), "string", "time-span", "System.TimeSpan", true)]
         [TestCase("EchoNullableEnum", typeof(PrimitiveEnum?), "integer", "int32", "Swashbuckle.Dummy.Types.PrimitiveEnum", true)]
         [TestCase("EchoNullableEnum", typeof(PrimitiveEnum?), "string", null, "Swashbuckle.Dummy.Types.PrimitiveEnum", true)]
         [TestCase("EchoNullableChar", typeof(char?), "string", null, "System.Char", true)]


### PR DESCRIPTION
Currently many Swagger code generators (e.g. NSwag) support `time-span` format. I think it is a good idea to support `TimeSpan` datatype.