### PR TITLE
Add option to set custom templateParameters

### DIFF
--- a/Swashbuckle.Core/Application/SwaggerUiConfig.cs
+++ b/Swashbuckle.Core/Application/SwaggerUiConfig.cs
@@ -103,6 +103,15 @@ namespace Swashbuckle.Application
             if (path == "index") isTemplate = true;
             _pathToAssetMap[path] = new EmbeddedAssetDescriptor(resourceAssembly, resourceName, isTemplate);
         }
+	    
+        public void CustomTemplateParameter(string templateParameterName, string parameterValue)
+        {
+	    var nameWithPercentParenthesesWrapper =
+		templateParameterName.StartsWith("%(")
+		    ? templateParameterName
+		    : $"%({templateParameterName})";
+	    _templateParams[nameWithPercentParenthesesWrapper] = parameterValue;
+        }
 
         public void EnableDiscoveryUrlSelector()
         {


### PR DESCRIPTION
Add ability to define custom TemplateParameters.
Useful, for example, for injecting C# constant strings into the JS files that we want to c.InjectJavascript() into the Swagger page.

I've already tested that, for example, referencing %(DocumentTitle) in my injected Javascript file works, but I can't do that with my own template key, making the `isTemplate` parameter of `InjectJavascript()` pretty pointless.